### PR TITLE
Benchmark: add control driver

### DIFF
--- a/benchmark/Cargo.toml
+++ b/benchmark/Cargo.toml
@@ -17,14 +17,20 @@ libc = "0.2"
 grpcio-sys = { path = "../grpc-sys" }
 rand = "0.3"
 tokio-timer = "0.1"
-clap = "2.23"
-log = "0.3"
+clap = "2.33"
+log = "0.4"
+env_logger = "0.7"
 slog = "2.0"
 slog-async = "2.1"
 slog-stdlog = "3.0"
 slog-scope = "4.0"
 slog-term = "2.2"
+protobuf = "2.0"
+
+[[bin]]
+name = "run_driver"
+path = "src/bin/run_driver.rs"
 
 [[bin]]
 name = "qps_worker"
-path = "src/main.rs"
+path = "src/bin/qps_worker.rs"

--- a/benchmark/src/bin/run_driver.rs
+++ b/benchmark/src/bin/run_driver.rs
@@ -1,0 +1,29 @@
+#[macro_use]
+extern crate log;
+
+use benchmark::driver::run_worker;
+use benchmark::scenario;
+use clap::{App, Arg};
+
+fn main() {
+    // initialization
+    env_logger::init();
+    let matches = App::new("Test Controller")
+        .arg(
+            Arg::with_name("Address")
+                .long("addr")
+                .help("The workers to connect")
+                .min_values(2),
+        )
+        .get_matches();
+    let addrs: Vec<String> = if let Some(addr_matches) = matches.values_of("Address") {
+        addr_matches.map(String::from).collect()
+    } else {
+        vec![]
+    };
+
+    info!("{:?}", addrs);
+    // run test
+    run_worker(scenario::async_unary_1channel_1000rpcs_1mb(), addrs.clone());
+    info!("Control Driver Shutdown");
+}

--- a/benchmark/src/bin/run_driver.rs
+++ b/benchmark/src/bin/run_driver.rs
@@ -24,6 +24,6 @@ fn main() {
 
     info!("{:?}", addrs);
     // run test
-    run_worker(scenario::async_unary_1channel_1000rpcs_1mb(), addrs.clone());
+    run_worker(scenario::async_stream_8channel_320rpcs_64kb(), addrs.clone());
     info!("Control Driver Shutdown");
 }

--- a/benchmark/src/driver.rs
+++ b/benchmark/src/driver.rs
@@ -46,7 +46,7 @@ pub fn run_worker(s: Scenario, mut worker_addrs: Vec<String>) -> ScenarioResult 
     // Connect to server workers
     let env = Arc::new(Environment::new(2));
     let mut servers = vec![];
-    for addr in worker_addrs.iter() {
+    for addr in worker_addrs.iter().take(num_servers) {
         let ch = ChannelBuilder::new(env.clone()).connect(addr.as_str());
         let client = WorkerServiceClient::new(ch);
         let (tx, rx) = client.run_server().unwrap();
@@ -341,6 +341,13 @@ fn postprocess_scenario_result(result: &mut ScenarioResult) {
     result
         .mut_summary()
         .set_qps_per_server_core(qps_per_server_core);
+
+    result.mut_summary().set_latency_50(his.percentile(50.0));
+    result.mut_summary().set_latency_90(his.percentile(90.0));
+    result.mut_summary().set_latency_95(his.percentile(95.0));
+    result.mut_summary().set_latency_99(his.percentile(99.0));
+    result.mut_summary().set_latency_999(his.percentile(999.0));
+
     let server_system_time = 100.0 * sum(result.get_server_stats(), |s| s.get_time_system())
         / sum(result.get_server_stats(), |s| s.get_time_elapsed());
     let server_user_time = 100.0 * sum(result.get_server_stats(), |s| s.get_time_user())

--- a/benchmark/src/driver.rs
+++ b/benchmark/src/driver.rs
@@ -1,0 +1,413 @@
+use crate::create_worker;
+use crate::util::{average, sum, Histogram};
+use futures::{future, Future, Sink, Stream};
+use grpcio::{ChannelBuilder, Environment, WriteFlags};
+use grpcio::{ClientDuplexReceiver, ClientDuplexSender};
+use grpcio_proto::testing::control::{
+    ClientArgs, ClientConfig, ClientStatus, Mark, Scenario, ScenarioResult, ServerArgs,
+    ServerConfig, ServerStatus, Void,
+};
+
+use grpcio_proto::testing::services_grpc::WorkerServiceClient;
+use grpcio_proto::testing::stats::RequestResultCount;
+use protobuf::RepeatedField;
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::thread;
+
+/// Send control information to run the test, if there
+/// are no workers available, start the workers locally.
+#[allow(clippy::cognitive_complexity)]
+pub fn run_worker(s: Scenario, mut worker_addrs: Vec<String>) -> ScenarioResult {
+    // Parse the scenario
+    let client_config = s.get_client_config();
+    let server_config = s.get_server_config();
+    let warmup_seconds = s.get_warmup_seconds() as u64;
+    let benchmark_seconds = s.get_benchmark_seconds() as u64;
+    let num_clients = s.get_num_clients() as usize;
+    let num_servers = s.get_num_servers() as usize;
+    let mut result = ScenarioResult::new();
+    let mut merged_latencies = Histogram::new(0.01, 60e9);
+    let mut merged_statuses = HashMap::new();
+    // Create workers
+    if worker_addrs.is_empty() {
+        for i in 0..2 {
+            worker_addrs.push(format!("0.0.0.0:{}", 8080 + i));
+            thread::spawn(move || {
+                create_worker(8080 + i);
+            });
+        }
+    } else {
+        assert_eq!(num_clients + num_servers, worker_addrs.len());
+    }
+    for addr in &worker_addrs {
+        info!("Driver is ready to connect {}", addr);
+    }
+    // Connect to server workers
+    let env = Arc::new(Environment::new(2));
+    let mut servers = vec![];
+    for addr in worker_addrs.iter() {
+        let ch = ChannelBuilder::new(env.clone()).connect(addr.as_str());
+        let client = WorkerServiceClient::new(ch);
+        let (tx, rx) = client.run_server().unwrap();
+        servers.push(ServerWorker {
+            client,
+            tx: Some(tx),
+            rx: Some(rx),
+        });
+    }
+    // Connect to client workers
+    let mut clients = vec![];
+    for i in 0..num_clients {
+        let addr = worker_addrs[i + num_servers].clone();
+        let ch = ChannelBuilder::new(env.clone()).connect(addr.as_str());
+        let client = WorkerServiceClient::new(ch);
+        let (tx, rx) = client.run_client().unwrap();
+        clients.push(ClientWorker {
+            client,
+            tx: Some(tx),
+            rx: Some(rx),
+        });
+    }
+    // Configure port for servers
+    // Run servers
+    for (i, worker) in servers.iter_mut().enumerate() {
+        let mut config = server_config.clone();
+        config.set_port(50000 + i as i32);
+        let args = create_server_args(config);
+        let new_tx = worker
+            .tx
+            .take()
+            .unwrap()
+            .send((args, WriteFlags::default()))
+            .wait()
+            .unwrap();
+        worker.tx.replace(new_tx);
+        match worker.rx.take().unwrap().into_future().wait() {
+            Ok((Some(status), new_rx)) => {
+                info!("Run server on port {}", status.get_port());
+                worker.rx.replace(new_rx);
+            }
+            Err((e, _)) => panic!("Get server status failed: {:?}", e),
+            _ => unimplemented!(),
+        }
+    }
+    // Configure server targets (Todo: support identify outer address)
+    // Run clients
+    for worker in clients.iter_mut() {
+        let mut config = client_config.clone();
+        let mut target_list = vec![];
+        for index in 0..num_servers {
+            target_list.push(format!("0.0.0.0:{}", 50000 + index as i32));
+        }
+        config.set_server_targets(create_server_targets(target_list.clone()));
+        let args = create_client_args(config);
+        let new_tx = worker
+            .tx
+            .take()
+            .unwrap()
+            .send((args, WriteFlags::default()))
+            .wait()
+            .unwrap();
+        worker.tx.replace(new_tx);
+        match worker.rx.take().unwrap().into_future().wait() {
+            Ok((Some(_), new_rx)) => {
+                info!("Run client to ports {:?}", target_list);
+                worker.rx.replace(new_rx);
+            }
+            Err((e, _)) => panic!("Get client status failed: {:?}", e),
+            _ => unimplemented!(),
+        }
+    }
+    // Initialization
+    let server_mark = create_server_args_mark(true);
+    let client_mark = create_client_args_mark(true);
+    for worker in clients.iter_mut() {
+        let new_tx = worker
+            .tx
+            .take()
+            .unwrap()
+            .send((client_mark.clone(), WriteFlags::default()))
+            .wait()
+            .unwrap();
+        worker.tx.replace(new_tx);
+        match worker.rx.take().unwrap().into_future().wait() {
+            Ok((Some(_), new_rx)) => {
+                info!("Initialized");
+                worker.rx.replace(new_rx);
+            }
+            Err((e, _)) => panic!("Get client status failed: {:?}", e),
+            _ => unimplemented!(),
+        }
+    }
+    // Let everything warmup
+    info!("Warming up...");
+    thread::sleep(std::time::Duration::from_secs(warmup_seconds));
+    // Start a Run
+    for worker in servers.iter_mut() {
+        let new_tx = worker
+            .tx
+            .take()
+            .unwrap()
+            .send((server_mark.clone(), WriteFlags::default()))
+            .wait()
+            .unwrap();
+        worker.tx.replace(new_tx);
+    }
+    for worker in clients.iter_mut() {
+        let new_tx = worker
+            .tx
+            .take()
+            .unwrap()
+            .send((client_mark.clone(), WriteFlags::default()))
+            .wait()
+            .unwrap();
+        worker.tx.replace(new_tx);
+    }
+    for worker in servers.iter_mut() {
+        match worker.rx.take().unwrap().into_future().wait() {
+            Ok((Some(_), new_rx)) => {
+                worker.rx.replace(new_rx);
+            }
+            Err((e, _)) => panic!("Get server status failed: {:?}", e),
+            _ => unimplemented!(),
+        }
+    }
+    for worker in clients.iter_mut() {
+        match worker.rx.take().unwrap().into_future().wait() {
+            Ok((Some(_), new_rx)) => {
+                worker.rx.replace(new_rx);
+            }
+            Err((e, _)) => panic!("Get client status failed: {:?}", e),
+            _ => unimplemented!(),
+        }
+    }
+    info!("Running...");
+    thread::sleep(std::time::Duration::from_secs(benchmark_seconds));
+    // Finish write client
+    for worker in clients.iter_mut() {
+        let new_tx = worker
+            .tx
+            .take()
+            .unwrap()
+            .send((client_mark.clone(), WriteFlags::default()))
+            .wait()
+            .unwrap();
+        worker.tx.replace(new_tx);
+        future::poll_fn(|| worker.tx.as_mut().unwrap().close())
+            .wait()
+            .unwrap();
+    }
+    // Read Client Stats
+    for worker in clients.iter_mut() {
+        match worker.rx.take().unwrap().into_future().wait() {
+            Ok((Some(mut status), new_rx)) => {
+                let stats = status.take_stats();
+                merged_latencies.merge_proto(stats.get_latencies());
+                for request_result in stats.get_request_results() {
+                    let code = request_result.get_status_code();
+                    let count = request_result.get_count();
+                    if let Some(val) = merged_statuses.get_mut(&code) {
+                        *val += count;
+                    } else {
+                        merged_statuses.insert(code, count);
+                    }
+                }
+                result.mut_client_stats().push(stats);
+                // hack code
+                result.mut_client_success().push(true);
+                if let Ok((None, new_rx)) = new_rx.into_future().wait() {
+                    worker.rx.replace(new_rx);
+                } else {
+                    panic!("final status should be the last message on the client stream");
+                }
+            }
+            Err((e, _)) => panic!("Get client status failed: {:?}", e),
+            _ => unimplemented!(),
+        }
+    }
+    // Fill proto and request results
+    merged_latencies.fill_proto(result.mut_latencies());
+    for (key, val) in merged_statuses.iter() {
+        let mut result_count = RequestResultCount::new();
+        result_count.set_count(val.clone());
+        result_count.set_status_code(key.clone());
+        result.mut_request_results().push(result_count);
+    }
+    // Finish Server
+    for worker in servers.iter_mut() {
+        let new_tx = worker
+            .tx
+            .take()
+            .unwrap()
+            .send((server_mark.clone(), WriteFlags::default()))
+            .wait()
+            .unwrap();
+        worker.tx.replace(new_tx);
+        future::poll_fn(|| worker.tx.as_mut().unwrap().close())
+            .wait()
+            .unwrap();
+    }
+    // Read Server Stats
+    for worker in servers.iter_mut() {
+        match worker.rx.take().unwrap().into_future().wait() {
+            Ok((Some(mut status), new_rx)) => {
+                let stats = status.take_stats();
+                let cores = status.get_cores();
+                result.mut_server_stats().push(stats);
+                result.mut_server_cores().push(cores);
+                // hack code
+                result.mut_server_success().push(true);
+                if let Ok((None, new_rx)) = new_rx.into_future().wait() {
+                    worker.rx.replace(new_rx);
+                } else {
+                    panic!("final status should be the last message on the server stream");
+                }
+            }
+            Err((e, _)) => panic!("Get server status failed: {:?}", e),
+            _ => unimplemented!(),
+        }
+    }
+    // Quit worker
+    for worker in clients.iter_mut() {
+        let _ = worker.client.quit_worker(&Void::new());
+    }
+    for worker in servers.iter_mut() {
+        let _ = worker.client.quit_worker(&Void::new());
+    }
+    thread::sleep(std::time::Duration::from_secs(3));
+    // Post handle
+    postprocess_scenario_result(&mut result);
+    info!("{:?}", result.get_summary());
+    result
+}
+
+pub fn create_server_args(config: ServerConfig) -> ServerArgs {
+    let mut arg = ServerArgs::new();
+    arg.set_setup(config);
+    arg
+}
+
+pub fn create_server_args_mark(m: bool) -> ServerArgs {
+    let mut arg = ServerArgs::new();
+    let mut mark = Mark::new();
+    mark.set_reset(m);
+    arg.set_mark(mark);
+    arg
+}
+
+pub fn create_client_args(config: ClientConfig) -> ClientArgs {
+    let mut arg = ClientArgs::new();
+    arg.set_setup(config);
+    arg
+}
+
+pub fn create_client_args_mark(m: bool) -> ClientArgs {
+    let mut arg = ClientArgs::new();
+    let mut mark = Mark::new();
+    mark.set_reset(m);
+    arg.set_mark(mark);
+    arg
+}
+
+fn create_server_targets(vec: Vec<String>) -> RepeatedField<String> {
+    RepeatedField::from_vec(vec)
+}
+
+struct ServerWorker {
+    client: WorkerServiceClient,
+    tx: Option<ClientDuplexSender<ServerArgs>>,
+    rx: Option<ClientDuplexReceiver<ServerStatus>>,
+}
+
+struct ClientWorker {
+    client: WorkerServiceClient,
+    tx: Option<ClientDuplexSender<ClientArgs>>,
+    rx: Option<ClientDuplexReceiver<ClientStatus>>,
+}
+
+fn postprocess_scenario_result(result: &mut ScenarioResult) {
+    let mut his = Histogram::new(0.01, 60e9);
+    his.merge_proto(result.mut_latencies());
+
+    let time_estimate = average(result.get_client_stats(), |s| s.get_time_elapsed());
+    let qps = his.get_count() / time_estimate;
+    let mut sum_qps = 0f64;
+    for i in result.get_server_cores() {
+        sum_qps += f64::from(*i);
+    }
+    let qps_per_server_core = qps / sum_qps;
+    result.mut_summary().set_qps(qps);
+    result
+        .mut_summary()
+        .set_qps_per_server_core(qps_per_server_core);
+    let server_system_time = 100.0 * sum(result.get_server_stats(), |s| s.get_time_system())
+        / sum(result.get_server_stats(), |s| s.get_time_elapsed());
+    let server_user_time = 100.0 * sum(result.get_server_stats(), |s| s.get_time_user())
+        / sum(result.get_server_stats(), |s| s.get_time_elapsed());
+    let client_system_time = 100.0 * sum(result.get_client_stats(), |s| s.get_time_system())
+        / sum(result.get_client_stats(), |s| s.get_time_elapsed());
+    let client_user_time = 100.0 * sum(result.get_client_stats(), |s| s.get_time_user())
+        / sum(result.get_client_stats(), |s| s.get_time_elapsed());
+
+    result
+        .mut_summary()
+        .set_server_system_time(server_system_time);
+    result.mut_summary().set_server_user_time(server_user_time);
+    result
+        .mut_summary()
+        .set_client_system_time(client_system_time);
+    result.mut_summary().set_client_user_time(client_user_time);
+
+    if average(result.get_server_stats(), |s| s.get_total_cpu_time() as f64) == 0f64 {
+        result.mut_summary().set_server_cpu_usage(0f64);
+    } else {
+        let server_cpu_usage = 100.0
+            - 100.0 * average(result.get_server_stats(), |s| s.get_idle_cpu_time() as f64)
+                / average(result.get_server_stats(), |s| s.get_total_cpu_time() as f64);
+        result.mut_summary().set_server_cpu_usage(server_cpu_usage);
+    }
+
+    if !result.get_request_results().is_empty() {
+        let mut successes = 0f64;
+        let mut failures = 0f64;
+        for i in result.get_request_results() {
+            if i.get_status_code() == 0 {
+                successes += i.get_count() as f64;
+            } else {
+                failures += i.get_count() as f64;
+            }
+        }
+        result
+            .mut_summary()
+            .set_successful_requests_per_second(successes / time_estimate);
+        result
+            .mut_summary()
+            .set_failed_requests_per_second(failures / time_estimate);
+    }
+    let client_polls_per_request =
+        sum(result.get_client_stats(), |s| s.get_cq_poll_count() as f64) / his.get_count();
+    result
+        .mut_summary()
+        .set_client_polls_per_request(client_polls_per_request);
+    let server_polls_per_request =
+        sum(result.get_server_stats(), |s| s.get_cq_poll_count() as f64) / his.get_count();
+    result
+        .mut_summary()
+        .set_server_polls_per_request(server_polls_per_request);
+
+    let server_queries_per_cpu_sec = his.get_count()
+        / (sum(result.get_server_stats(), |s| s.get_time_system())
+            + sum(result.get_server_stats(), |s| s.get_time_user()));
+
+    let client_queries_per_cpu_sec = his.get_count()
+        / (sum(result.get_client_stats(), |s| s.get_time_system())
+            + sum(result.get_client_stats(), |s| s.get_time_user()));
+
+    result
+        .mut_summary()
+        .set_server_queries_per_cpu_sec(server_queries_per_cpu_sec);
+    result
+        .mut_summary()
+        .set_client_queries_per_cpu_sec(client_queries_per_cpu_sec);
+}

--- a/benchmark/src/scenario.rs
+++ b/benchmark/src/scenario.rs
@@ -1,0 +1,297 @@
+use grpcio_proto::testing::control::{
+    ChannelArg, ChannelArg_oneof_value, ClientConfig, ClientType, RpcType, Scenario, ServerConfig,
+    ServerType,
+};
+use grpcio_proto::testing::payloads::{ByteBufferParams, PayloadConfig, SimpleProtoParams};
+use grpcio_proto::testing::stats::HistogramParams;
+use protobuf::RepeatedField;
+
+/**
+ * Other API: <test name> <args>
+ * Note: this is used to custom tests
+ */
+
+#[allow(dead_code)]
+pub fn async_unary_1channel_4rpcs_io50ms() -> Scenario {
+    let mut client = ClientConfig::new();
+    let mut server = ServerConfig::new();
+    // config server
+    server.set_server_type(ServerType::OTHER_SERVER);
+    server.set_other_server_api("sleep 50".to_string());
+    // config client
+    client.set_client_type(ClientType::ASYNC_CLIENT);
+    client.set_rpc_type(RpcType::UNARY);
+    client.set_histogram_params(create_histogram_params(0.01, 60e9));
+    client.set_other_client_api("custom".to_string());
+    client.set_client_channels(1);
+    client.set_outstanding_rpcs_per_channel(4);
+    // generate scenario
+    let mut s = Scenario::new();
+    s.set_client_config(client);
+    s.set_server_config(server);
+    s.set_num_clients(1);
+    s.set_num_servers(1);
+    s.set_warmup_seconds(1);
+    s.set_benchmark_seconds(600);
+    s
+}
+
+#[allow(dead_code)]
+pub fn async_unary_1channel_4rpcs_io50ms_1mb() -> Scenario {
+    let mut client = ClientConfig::new();
+    let mut server = ServerConfig::new();
+    // config server
+    server.set_server_type(ServerType::OTHER_SERVER);
+    server.set_other_server_api("sleep 50".to_string());
+    // config client
+    client.set_client_type(ClientType::ASYNC_CLIENT);
+    client.set_rpc_type(RpcType::UNARY);
+    client.set_histogram_params(create_histogram_params(0.01, 60e9));
+    client.set_other_client_api("custom".to_string());
+    client.set_client_channels(1);
+    client.set_outstanding_rpcs_per_channel(4);
+    let config = create_simple_config(1024 * 1024, 1024 * 1024);
+    client.set_payload_config(config);
+    // generate scenario
+    let mut s = Scenario::new();
+    s.set_client_config(client);
+    s.set_server_config(server);
+    s.set_num_clients(1);
+    s.set_num_servers(1);
+    s.set_warmup_seconds(1);
+    s.set_benchmark_seconds(600);
+    s
+}
+
+#[allow(dead_code)]
+pub fn async_unary_1channel_4rpcs_1mb() -> Scenario {
+    let mut client = ClientConfig::new();
+    let mut server = ServerConfig::new();
+    // config server
+    server.set_server_type(ServerType::OTHER_SERVER);
+    server.set_other_server_api("sleep 0".to_string());
+    // config client
+    client.set_client_type(ClientType::ASYNC_CLIENT);
+    client.set_rpc_type(RpcType::UNARY);
+    client.set_histogram_params(create_histogram_params(0.01, 60e9));
+    client.set_other_client_api("custom".to_string());
+    client.set_client_channels(1);
+    client.set_outstanding_rpcs_per_channel(4);
+    let config = create_simple_config(1024 * 1024, 1024 * 1024);
+    client.set_payload_config(config);
+    // generate scenario
+    let mut s = Scenario::new();
+    s.set_client_config(client);
+    s.set_server_config(server);
+    s.set_num_clients(1);
+    s.set_num_servers(1);
+    s.set_warmup_seconds(1);
+    s.set_benchmark_seconds(600);
+    s
+}
+
+#[allow(dead_code)]
+pub fn async_unary_1channel_1000rpcs_1mb() -> Scenario {
+    let mut client = ClientConfig::new();
+    let mut server = ServerConfig::new();
+    // config server
+    server.set_server_type(ServerType::OTHER_SERVER);
+    server.set_other_server_api("sleep 0".to_string());
+    // config client
+    client.set_client_type(ClientType::ASYNC_CLIENT);
+    client.set_rpc_type(RpcType::UNARY);
+    client.set_histogram_params(create_histogram_params(0.01, 60e9));
+    client.set_other_client_api("custom".to_string());
+    client.set_client_channels(1);
+    client.set_outstanding_rpcs_per_channel(1000);
+    let config = create_simple_config(1024 * 1024, 1024 * 1024);
+    client.set_payload_config(config);
+    // generate scenario
+    let mut s = Scenario::new();
+    s.set_client_config(client);
+    s.set_server_config(server);
+    s.set_num_clients(1);
+    s.set_num_servers(1);
+    s.set_warmup_seconds(1);
+    s.set_benchmark_seconds(600);
+    s
+}
+
+#[allow(dead_code)]
+pub fn async_unary_1channel_1000rpcs_64() -> Scenario {
+    let mut client = ClientConfig::new();
+    let mut server = ServerConfig::new();
+    // config server
+    server.set_server_type(ServerType::OTHER_SERVER);
+    server.set_other_server_api("sleep 0".to_string());
+    // config client
+    client.set_client_type(ClientType::ASYNC_CLIENT);
+    client.set_rpc_type(RpcType::UNARY);
+    client.set_histogram_params(create_histogram_params(0.01, 60e9));
+    client.set_other_client_api("custom".to_string());
+    client.set_client_channels(1);
+    client.set_outstanding_rpcs_per_channel(1000);
+    let config = create_simple_config(64, 64);
+    client.set_payload_config(config);
+    // generate scenario
+    let mut s = Scenario::new();
+    s.set_client_config(client);
+    s.set_server_config(server);
+    s.set_num_clients(1);
+    s.set_num_servers(1);
+    s.set_warmup_seconds(1);
+    s.set_benchmark_seconds(600);
+    s
+}
+
+#[allow(dead_code)]
+pub fn async_unary_1channel_1000rpcs_io500ms_32kb() -> Scenario {
+    let mut client = ClientConfig::new();
+    let mut server = ServerConfig::new();
+    // config server
+    server.set_server_type(ServerType::OTHER_SERVER);
+    server.set_other_server_api("sleep 500".to_string());
+    // config client
+    client.set_client_type(ClientType::ASYNC_CLIENT);
+    client.set_rpc_type(RpcType::UNARY);
+    client.set_histogram_params(create_histogram_params(0.01, 60e9));
+    client.set_other_client_api("custom".to_string());
+    client.set_client_channels(1);
+    client.set_outstanding_rpcs_per_channel(1000);
+    let config = create_simple_config(32, 32);
+    client.set_payload_config(config);
+    // generate scenario
+    let mut s = Scenario::new();
+    s.set_client_config(client);
+    s.set_server_config(server);
+    s.set_num_clients(1);
+    s.set_num_servers(1);
+    s.set_warmup_seconds(1);
+    s.set_benchmark_seconds(600);
+    s
+}
+
+#[allow(dead_code)]
+pub fn async_stream_8channel_1000rpcs_1mb() -> Scenario {
+    let mut client = ClientConfig::new();
+    let mut server = ServerConfig::new();
+    // config server
+    server.set_server_type(ServerType::OTHER_SERVER);
+    server.set_other_server_api("sleep 0".to_string());
+    // config client
+    client.set_client_type(ClientType::ASYNC_CLIENT);
+    client.set_rpc_type(RpcType::STREAMING);
+    client.set_histogram_params(create_histogram_params(0.01, 60e9));
+    client.set_other_client_api("custom".to_string());
+    client.set_client_channels(8);
+    client.set_outstanding_rpcs_per_channel(1000);
+    let config = create_simple_config(1024 * 1024, 1024 * 1024);
+    client.set_payload_config(config);
+    // generate scenario
+    let mut s = Scenario::new();
+    s.set_client_config(client);
+    s.set_server_config(server);
+    s.set_num_clients(1);
+    s.set_num_servers(1);
+    s.set_warmup_seconds(1);
+    s.set_benchmark_seconds(600);
+    s
+}
+
+#[allow(dead_code)]
+pub fn async_stream_1channel_100rpcs_1mb() -> Scenario {
+    let mut client = ClientConfig::new();
+    let mut server = ServerConfig::new();
+    // config server
+    server.set_server_type(ServerType::OTHER_SERVER);
+    server.set_other_server_api("sleep 0".to_string());
+    // config client
+    client.set_client_type(ClientType::ASYNC_CLIENT);
+    client.set_rpc_type(RpcType::STREAMING);
+    client.set_histogram_params(create_histogram_params(0.01, 60e9));
+    client.set_other_client_api("custom".to_string());
+    client.set_client_channels(1);
+    client.set_outstanding_rpcs_per_channel(100);
+    let config = create_simple_config(1024 * 1024, 1024 * 1024);
+    client.set_payload_config(config);
+    // generate scenario
+    let mut s = Scenario::new();
+    s.set_client_config(client);
+    s.set_server_config(server);
+    s.set_num_clients(1);
+    s.set_num_servers(1);
+    s.set_warmup_seconds(1);
+    s.set_benchmark_seconds(600);
+    s
+}
+
+#[allow(dead_code)]
+pub fn async_stream_4channel_100rpcs_16kb() -> Scenario {
+    let mut client = ClientConfig::new();
+    let mut server = ServerConfig::new();
+    // config server
+    server.set_server_type(ServerType::OTHER_SERVER);
+    server.set_other_server_api("sleep 0".to_string());
+    // config client
+    client.set_client_type(ClientType::ASYNC_CLIENT);
+    client.set_rpc_type(RpcType::STREAMING);
+    client.set_histogram_params(create_histogram_params(0.01, 60e9));
+    client.set_other_client_api("custom".to_string());
+    client.set_client_channels(4);
+    client.set_outstanding_rpcs_per_channel(100);
+    let config = create_simple_config(16, 16);
+    client.set_payload_config(config);
+    // generate scenario
+    let mut s = Scenario::new();
+    s.set_client_config(client);
+    s.set_server_config(server);
+    s.set_num_clients(1);
+    s.set_num_servers(1);
+    s.set_warmup_seconds(1);
+    s.set_benchmark_seconds(600);
+    s
+}
+
+#[allow(dead_code)]
+fn create_bytebuf_config(req_size: i32, resp_size: i32) -> PayloadConfig {
+    let mut p = ByteBufferParams::new();
+    let mut config = PayloadConfig::new();
+    p.set_req_size(req_size);
+    p.set_resp_size(resp_size);
+    config.set_bytebuf_params(p);
+    config
+}
+
+#[allow(dead_code)]
+fn create_simple_config(req_size: i32, resp_size: i32) -> PayloadConfig {
+    let mut p = SimpleProtoParams::new();
+    let mut config = PayloadConfig::new();
+    p.set_req_size(req_size);
+    p.set_resp_size(resp_size);
+    config.set_simple_params(p);
+    config
+}
+
+#[allow(dead_code)]
+fn create_channel_arg(name: String, arg_oneof_val: ChannelArg_oneof_value) -> ChannelArg {
+    let mut ret = ChannelArg::new();
+    ret.set_name(name);
+    match arg_oneof_val {
+        ChannelArg_oneof_value::str_value(val) => ret.set_str_value(val),
+        ChannelArg_oneof_value::int_value(val) => ret.set_int_value(val),
+    }
+    ret
+}
+
+#[allow(dead_code)]
+fn create_channel_arg_list(vec: Vec<ChannelArg>) -> RepeatedField<ChannelArg> {
+    RepeatedField::from_vec(vec)
+}
+
+#[allow(dead_code)]
+fn create_histogram_params(d1: f64, d2: f64) -> HistogramParams {
+    let mut params = HistogramParams::new();
+    params.set_resolution(d1);
+    params.set_max_possible(d2);
+    params
+}

--- a/benchmark/src/scenario.rs
+++ b/benchmark/src/scenario.rs
@@ -6,173 +6,8 @@ use grpcio_proto::testing::payloads::{ByteBufferParams, PayloadConfig, SimplePro
 use grpcio_proto::testing::stats::HistogramParams;
 use protobuf::RepeatedField;
 
-/**
- * Other API: <test name> <args>
- * Note: this is used to custom tests
- */
-
 #[allow(dead_code)]
-pub fn async_unary_1channel_4rpcs_io50ms() -> Scenario {
-    let mut client = ClientConfig::new();
-    let mut server = ServerConfig::new();
-    // config server
-    server.set_server_type(ServerType::OTHER_SERVER);
-    server.set_other_server_api("sleep 50".to_string());
-    // config client
-    client.set_client_type(ClientType::ASYNC_CLIENT);
-    client.set_rpc_type(RpcType::UNARY);
-    client.set_histogram_params(create_histogram_params(0.01, 60e9));
-    client.set_other_client_api("custom".to_string());
-    client.set_client_channels(1);
-    client.set_outstanding_rpcs_per_channel(4);
-    // generate scenario
-    let mut s = Scenario::new();
-    s.set_client_config(client);
-    s.set_server_config(server);
-    s.set_num_clients(1);
-    s.set_num_servers(1);
-    s.set_warmup_seconds(1);
-    s.set_benchmark_seconds(600);
-    s
-}
-
-#[allow(dead_code)]
-pub fn async_unary_1channel_4rpcs_io50ms_1mb() -> Scenario {
-    let mut client = ClientConfig::new();
-    let mut server = ServerConfig::new();
-    // config server
-    server.set_server_type(ServerType::OTHER_SERVER);
-    server.set_other_server_api("sleep 50".to_string());
-    // config client
-    client.set_client_type(ClientType::ASYNC_CLIENT);
-    client.set_rpc_type(RpcType::UNARY);
-    client.set_histogram_params(create_histogram_params(0.01, 60e9));
-    client.set_other_client_api("custom".to_string());
-    client.set_client_channels(1);
-    client.set_outstanding_rpcs_per_channel(4);
-    let config = create_simple_config(1024 * 1024, 1024 * 1024);
-    client.set_payload_config(config);
-    // generate scenario
-    let mut s = Scenario::new();
-    s.set_client_config(client);
-    s.set_server_config(server);
-    s.set_num_clients(1);
-    s.set_num_servers(1);
-    s.set_warmup_seconds(1);
-    s.set_benchmark_seconds(600);
-    s
-}
-
-#[allow(dead_code)]
-pub fn async_unary_1channel_4rpcs_1mb() -> Scenario {
-    let mut client = ClientConfig::new();
-    let mut server = ServerConfig::new();
-    // config server
-    server.set_server_type(ServerType::OTHER_SERVER);
-    server.set_other_server_api("sleep 0".to_string());
-    // config client
-    client.set_client_type(ClientType::ASYNC_CLIENT);
-    client.set_rpc_type(RpcType::UNARY);
-    client.set_histogram_params(create_histogram_params(0.01, 60e9));
-    client.set_other_client_api("custom".to_string());
-    client.set_client_channels(1);
-    client.set_outstanding_rpcs_per_channel(4);
-    let config = create_simple_config(1024 * 1024, 1024 * 1024);
-    client.set_payload_config(config);
-    // generate scenario
-    let mut s = Scenario::new();
-    s.set_client_config(client);
-    s.set_server_config(server);
-    s.set_num_clients(1);
-    s.set_num_servers(1);
-    s.set_warmup_seconds(1);
-    s.set_benchmark_seconds(600);
-    s
-}
-
-#[allow(dead_code)]
-pub fn async_unary_1channel_1000rpcs_1mb() -> Scenario {
-    let mut client = ClientConfig::new();
-    let mut server = ServerConfig::new();
-    // config server
-    server.set_server_type(ServerType::OTHER_SERVER);
-    server.set_other_server_api("sleep 0".to_string());
-    // config client
-    client.set_client_type(ClientType::ASYNC_CLIENT);
-    client.set_rpc_type(RpcType::UNARY);
-    client.set_histogram_params(create_histogram_params(0.01, 60e9));
-    client.set_other_client_api("custom".to_string());
-    client.set_client_channels(1);
-    client.set_outstanding_rpcs_per_channel(1000);
-    let config = create_simple_config(1024 * 1024, 1024 * 1024);
-    client.set_payload_config(config);
-    // generate scenario
-    let mut s = Scenario::new();
-    s.set_client_config(client);
-    s.set_server_config(server);
-    s.set_num_clients(1);
-    s.set_num_servers(1);
-    s.set_warmup_seconds(1);
-    s.set_benchmark_seconds(600);
-    s
-}
-
-#[allow(dead_code)]
-pub fn async_unary_1channel_1000rpcs_64() -> Scenario {
-    let mut client = ClientConfig::new();
-    let mut server = ServerConfig::new();
-    // config server
-    server.set_server_type(ServerType::OTHER_SERVER);
-    server.set_other_server_api("sleep 0".to_string());
-    // config client
-    client.set_client_type(ClientType::ASYNC_CLIENT);
-    client.set_rpc_type(RpcType::UNARY);
-    client.set_histogram_params(create_histogram_params(0.01, 60e9));
-    client.set_other_client_api("custom".to_string());
-    client.set_client_channels(1);
-    client.set_outstanding_rpcs_per_channel(1000);
-    let config = create_simple_config(64, 64);
-    client.set_payload_config(config);
-    // generate scenario
-    let mut s = Scenario::new();
-    s.set_client_config(client);
-    s.set_server_config(server);
-    s.set_num_clients(1);
-    s.set_num_servers(1);
-    s.set_warmup_seconds(1);
-    s.set_benchmark_seconds(600);
-    s
-}
-
-#[allow(dead_code)]
-pub fn async_unary_1channel_1000rpcs_io500ms_32kb() -> Scenario {
-    let mut client = ClientConfig::new();
-    let mut server = ServerConfig::new();
-    // config server
-    server.set_server_type(ServerType::OTHER_SERVER);
-    server.set_other_server_api("sleep 500".to_string());
-    // config client
-    client.set_client_type(ClientType::ASYNC_CLIENT);
-    client.set_rpc_type(RpcType::UNARY);
-    client.set_histogram_params(create_histogram_params(0.01, 60e9));
-    client.set_other_client_api("custom".to_string());
-    client.set_client_channels(1);
-    client.set_outstanding_rpcs_per_channel(1000);
-    let config = create_simple_config(32, 32);
-    client.set_payload_config(config);
-    // generate scenario
-    let mut s = Scenario::new();
-    s.set_client_config(client);
-    s.set_server_config(server);
-    s.set_num_clients(1);
-    s.set_num_servers(1);
-    s.set_warmup_seconds(1);
-    s.set_benchmark_seconds(600);
-    s
-}
-
-#[allow(dead_code)]
-pub fn async_stream_8channel_1000rpcs_1mb() -> Scenario {
+pub fn async_stream_8channel_320rpcs_64kb() -> Scenario {
     let mut client = ClientConfig::new();
     let mut server = ServerConfig::new();
     // config server
@@ -184,8 +19,8 @@ pub fn async_stream_8channel_1000rpcs_1mb() -> Scenario {
     client.set_histogram_params(create_histogram_params(0.01, 60e9));
     client.set_other_client_api("custom".to_string());
     client.set_client_channels(8);
-    client.set_outstanding_rpcs_per_channel(1000);
-    let config = create_simple_config(1024 * 1024, 1024 * 1024);
+    client.set_outstanding_rpcs_per_channel(320);
+    let config = create_simple_config(64, 64);
     client.set_payload_config(config);
     // generate scenario
     let mut s = Scenario::new();
@@ -194,61 +29,7 @@ pub fn async_stream_8channel_1000rpcs_1mb() -> Scenario {
     s.set_num_clients(1);
     s.set_num_servers(1);
     s.set_warmup_seconds(1);
-    s.set_benchmark_seconds(600);
-    s
-}
-
-#[allow(dead_code)]
-pub fn async_stream_1channel_100rpcs_1mb() -> Scenario {
-    let mut client = ClientConfig::new();
-    let mut server = ServerConfig::new();
-    // config server
-    server.set_server_type(ServerType::OTHER_SERVER);
-    server.set_other_server_api("sleep 0".to_string());
-    // config client
-    client.set_client_type(ClientType::ASYNC_CLIENT);
-    client.set_rpc_type(RpcType::STREAMING);
-    client.set_histogram_params(create_histogram_params(0.01, 60e9));
-    client.set_other_client_api("custom".to_string());
-    client.set_client_channels(1);
-    client.set_outstanding_rpcs_per_channel(100);
-    let config = create_simple_config(1024 * 1024, 1024 * 1024);
-    client.set_payload_config(config);
-    // generate scenario
-    let mut s = Scenario::new();
-    s.set_client_config(client);
-    s.set_server_config(server);
-    s.set_num_clients(1);
-    s.set_num_servers(1);
-    s.set_warmup_seconds(1);
-    s.set_benchmark_seconds(600);
-    s
-}
-
-#[allow(dead_code)]
-pub fn async_stream_4channel_100rpcs_16kb() -> Scenario {
-    let mut client = ClientConfig::new();
-    let mut server = ServerConfig::new();
-    // config server
-    server.set_server_type(ServerType::OTHER_SERVER);
-    server.set_other_server_api("sleep 0".to_string());
-    // config client
-    client.set_client_type(ClientType::ASYNC_CLIENT);
-    client.set_rpc_type(RpcType::STREAMING);
-    client.set_histogram_params(create_histogram_params(0.01, 60e9));
-    client.set_other_client_api("custom".to_string());
-    client.set_client_channels(4);
-    client.set_outstanding_rpcs_per_channel(100);
-    let config = create_simple_config(16, 16);
-    client.set_payload_config(config);
-    // generate scenario
-    let mut s = Scenario::new();
-    s.set_client_config(client);
-    s.set_server_config(server);
-    s.set_num_clients(1);
-    s.set_num_servers(1);
-    s.set_warmup_seconds(1);
-    s.set_benchmark_seconds(600);
+    s.set_benchmark_seconds(10);
     s
 }
 

--- a/proto/proto/grpc/testing/messages.proto
+++ b/proto/proto/grpc/testing/messages.proto
@@ -167,3 +167,10 @@ message ReconnectInfo {
   bool passed = 1;
   repeated int32 backoff_ms = 2;
 }
+
+message SimpleMessage {
+  // expected size to response
+  int32 expect_size = 1;
+  // message body
+  bytes body = 2;
+}

--- a/proto/proto/grpc/testing/services.proto
+++ b/proto/proto/grpc/testing/services.proto
@@ -69,6 +69,11 @@ service WorkerService {
   rpc QuitWorker(Void) returns (Void);
 }
 
+service SimpleService {
+  rpc UnaryCall(SimpleMessage) returns (SimpleMessage);
+  rpc StreamingCall(stream SimpleMessage) returns (stream SimpleMessage);
+}
+
 service ReportQpsScenarioService {
   // Report results of a QPS test benchmark scenario.
   rpc ReportScenario(ScenarioResult) returns (Void);


### PR DESCRIPTION
The control side of the benchmark is provided [here](https://github.com/pingcap/grpc/tree/4158bd07777a147f95f9df03efdfe924be43a956/test/cpp/qps), although it can be used, but it is very troublesome. Now we need to provide some custom tests, such as stability related, so we need our own driver.

**Note**: The current implementation is not perfect, because this PR is too big, I need to split it into two, the first step to complete the driver, the second step to enrich the tikv related scenario.

[issue](https://github.com/pingcap/grpc-rs/issues/385)