### PR TITLE
executor: fix deadlock

### DIFF
--- a/src/env.rs
+++ b/src/env.rs
@@ -39,8 +39,8 @@ fn poll_queue(tx: mpsc::Sender<CompletionQueue>) {
         let tag: Box<CallTag> = unsafe { Box::from_raw(e.tag as _) };
 
         tag.resolve(&cq, e.success != 0);
-        while let Some(work) = cq.worker_info().pop_work() {
-            work.finish();
+        while let Some(work) = cq.worker.pop_work() {
+            work.finish(&cq);
         }
     }
 }

--- a/src/env.rs
+++ b/src/env.rs
@@ -26,7 +26,7 @@ fn poll_queue(tx: mpsc::Sender<CompletionQueue>) {
     let cq = Arc::new(CompletionQueueHandle::new());
     let worker_info = Arc::new(WorkQueue::new());
     let cq = CompletionQueue::new(cq, worker_info);
-    let _ = tx.send(cq.clone());
+    tx.send(cq.clone()).expect("send back completion queue");
     loop {
         let e = cq.next();
         match e.type_ {

--- a/src/task/executor.rs
+++ b/src/task/executor.rs
@@ -114,9 +114,10 @@ impl SpawnTask {
                     Ordering::AcqRel,
                     Ordering::Acquire,
                 ) {
-                    Err(IDLE) => continue,
+                    Err(IDLE) | Err(POLLING) => continue,
                     _ => return false,
                 },
+                Err(IDLE) => continue,
                 _ => return false,
             }
         }

--- a/src/task/executor.rs
+++ b/src/task/executor.rs
@@ -11,13 +11,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::cell::UnsafeCell;
+use std::sync::atomic::{AtomicU8, Ordering};
 use std::sync::Arc;
-use std::thread;
+use std::{mem, ptr};
 
 use futures::executor::{self, Notify, Spawn};
 use futures::{Async, Future};
 
-use super::lock::SpinLock;
 use super::CallTag;
 use crate::call::Call;
 use crate::cq::{CompletionQueue, WorkerInfo};
@@ -70,95 +71,151 @@ impl Clone for Kicker {
     }
 }
 
-struct NotifyContext {
-    kicked: bool,
-    kicker: Kicker,
-}
-
-impl NotifyContext {
-    /// Notify the completion queue.
-    ///
-    /// It only makes sense to call this function from the thread
-    /// that cq is not run on.
-    fn notify(&mut self, tag: Box<CallTag>) {
-        match self.kicker.kick(tag) {
-            // If the queue is shutdown, then the tag will be notified
-            // eventually. So just skip here.
-            Err(Error::QueueShutdown) => (),
-            Err(e) => panic!("unexpected error when canceling call: {:?}", e),
-            _ => (),
-        }
-    }
-}
+const NOTIFIED: u8 = 1;
+const IDLE: u8 = 2;
+const POLLING: u8 = 3;
+const COMPLETED: u8 = 4;
 
 /// A custom notify.
 ///
 /// It will poll the inner future directly if it's notified on the
 /// same thread as inner cq.
-#[derive(Clone)]
-pub struct SpawnNotify {
-    ctx: Arc<SpinLock<NotifyContext>>,
-    handle: Arc<SpinLock<SpawnHandle>>,
+pub struct SpawnTask {
+    handle: UnsafeCell<SpawnHandle>,
+    state: AtomicU8,
+    kicker: Kicker,
     worker: Arc<WorkerInfo>,
 }
 
-impl SpawnNotify {
-    fn new(s: Spawn<BoxFuture<(), ()>>, kicker: Kicker, worker: Arc<WorkerInfo>) -> SpawnNotify {
-        SpawnNotify {
+impl SpawnTask {
+    fn new(s: Spawn<BoxFuture<(), ()>>, kicker: Kicker, worker: Arc<WorkerInfo>) -> SpawnTask {
+        SpawnTask {
             worker,
-            handle: Arc::new(SpinLock::new(Some(s))),
-            ctx: Arc::new(SpinLock::new(NotifyContext {
-                kicked: false,
-                kicker,
-            })),
+            handle: UnsafeCell::new(Some(s)),
+            state: AtomicU8::new(IDLE),
+            kicker,
         }
     }
 
-    pub fn resolve(self, success: bool) {
-        // it should always be canceled for now.
-        assert!(success);
-        poll(&Arc::new(self.clone()), true);
+    /// Notify the completion queue.
+    ///
+    /// It only makes sense to call this function from the thread
+    /// that cq is not run on.
+    fn mark_notified(&self) -> bool {
+        loop {
+            match self.state.compare_exchange_weak(
+                IDLE,
+                NOTIFIED,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            ) {
+                Ok(_) => return true,
+                Err(POLLING) => match self.state.compare_exchange_weak(
+                    POLLING,
+                    NOTIFIED,
+                    Ordering::AcqRel,
+                    Ordering::Acquire,
+                ) {
+                    Err(IDLE) => continue,
+                    _ => return false,
+                },
+                _ => return false,
+            }
+        }
     }
 }
 
-impl Notify for SpawnNotify {
-    fn notify(&self, _: usize) {
-        match self.worker.begin_poll(thread::current().id()) {
-            Some(_lease) => poll(&Arc::new(self.clone()), false),
-            None => {
-                // TODO: it's more friendly to cache if poll it immediately
-                // if the worker thread id is still equal to current. However
-                // we need a way to prevent deadlocks and stack overflows.
-                let mut ctx = self.ctx.lock();
-                if ctx.kicked {
-                    return;
-                }
-                ctx.notify(Box::new(CallTag::Spawn(self.clone())));
-                ctx.kicked = true;
+pub fn resolve(task: Arc<SpawnTask>, success: bool) {
+    // it should always be canceled for now.
+    assert!(success);
+    poll(task, true);
+}
+
+#[derive(Clone)]
+struct Notifier;
+
+impl Notify for Notifier {
+    fn notify(&self, id: usize) {
+        let task = unsafe { Arc::from_raw(id as *mut SpawnTask) };
+        if !task.mark_notified() {
+            mem::forget(task);
+            return;
+        }
+
+        if let Some(UnfinishedWork(w)) = task.worker.push_work(UnfinishedWork(task.clone())) {
+            match task.kicker.kick(Box::new(CallTag::Spawn(w))) {
+                // If the queue is shutdown, then the tag will be notified
+                // eventually. So just skip here.
+                Err(Error::QueueShutdown) => (),
+                Err(e) => panic!("unexpected error when canceling call: {:?}", e),
+                _ => (),
             }
         }
+        mem::forget(task);
+    }
+
+    fn clone_id(&self, id: usize) -> usize {
+        let task = unsafe { Arc::from_raw(id as *mut SpawnTask) };
+        let t = task.clone();
+        mem::forget(task);
+        Arc::into_raw(t) as usize
+    }
+
+    fn drop_id(&self, id: usize) {
+        unsafe { Arc::from_raw(id as *mut SpawnTask) };
+    }
+}
+
+pub struct UnfinishedWork(Arc<SpawnTask>);
+
+impl UnfinishedWork {
+    pub fn finish(self) {
+        resolve(self.0, true);
     }
 }
 
 /// Poll the future.
 ///
 /// `woken` indicates that if the cq is kicked by itself.
-fn poll(notify: &Arc<SpawnNotify>, woken: bool) {
-    let mut handle = notify.handle.lock();
-    if woken {
-        notify.ctx.lock().kicked = false;
-    }
-    if handle.is_none() {
-        // it's resolved, no need to poll again.
-        return;
-    }
-    match handle.as_mut().unwrap().poll_future_notify(notify, 0) {
-        Err(_) | Ok(Async::Ready(_)) => {
-            // Future stores notify, and notify contains future,
-            // hence circular reference. Take the future to break it.
-            handle.take();
+fn poll(task: Arc<SpawnTask>, woken: bool) {
+    let mut init_state = if woken { NOTIFIED } else { IDLE };
+    loop {
+        match task
+            .state
+            .compare_exchange(init_state, POLLING, Ordering::SeqCst, Ordering::Acquire)
+        {
+            Ok(_) => {}
+            Err(COMPLETED) => return,
+            Err(s) => panic!("unexpected state {}", s),
         }
-        _ => {}
+
+        let id = &*task as *const SpawnTask as usize;
+        let p: &'static _ = unsafe { &*(ptr::null_mut() as *mut Notifier) };
+
+        match unsafe { &mut *task.handle.get() }
+            .as_mut()
+            .unwrap()
+            .poll_future_notify(&p, id)
+        {
+            Err(_) | Ok(Async::Ready(_)) => {
+                task.state.store(COMPLETED, Ordering::SeqCst);
+                unsafe { &mut *task.handle.get() }.take();
+            }
+            _ => {
+                match task.state.compare_exchange(
+                    POLLING,
+                    IDLE,
+                    Ordering::SeqCst,
+                    Ordering::Acquire,
+                ) {
+                    Ok(_) => return,
+                    Err(NOTIFIED) => {
+                        init_state = NOTIFIED;
+                    }
+                    Err(s) => panic!("unexpected state {}", s),
+                }
+            }
+        }
     }
 }
 
@@ -186,7 +243,7 @@ impl<'a> Executor<'a> {
         F: Future<Item = (), Error = ()> + Send + 'static,
     {
         let s = executor::spawn(Box::new(f) as BoxFuture<_, _>);
-        let notify = Arc::new(SpawnNotify::new(s, kicker, self.cq.worker_info()));
-        poll(&notify, false)
+        let notify = Arc::new(SpawnTask::new(s, kicker, self.cq.worker_info().clone()));
+        poll(notify, false)
     }
 }

--- a/src/task/executor.rs
+++ b/src/task/executor.rs
@@ -186,10 +186,10 @@ impl Notify for WorkQueue {
     }
 }
 
-/// Work that should be differred to be handled.
+/// Work that should be deferred to be handled.
 ///
-/// Sometimes a work can't be done imediately as it might lead
-/// to resourse conflict, deadlock for example. So they will be
+/// Sometimes a work can't be done immediately as it might lead
+/// to resource conflict, deadlock for example. So they will be
 /// pushed into a queue and handled when current work is done.
 pub struct UnfinishedWork(Arc<SpawnTask>);
 

--- a/src/task/executor.rs
+++ b/src/task/executor.rs
@@ -111,7 +111,7 @@ impl SpawnTask {
     }
 
     /// Marks the state of this task to NOTIFIED.
-    /// 
+    ///
     /// Returns true means the task was IDLE, needs to be scheduled.
     fn mark_notified(&self) -> bool {
         loop {
@@ -216,6 +216,7 @@ fn poll(cq: &CompletionQueue, task: Arc<SpawnTask>, woken: bool) {
 
         let id = &*task as *const SpawnTask as usize;
 
+        // L208 "lock"s state, hence it's safe to get a mutable reference.
         match unsafe { &mut *task.handle.get() }
             .as_mut()
             .unwrap()

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -188,7 +188,7 @@ impl CallTag {
             CallTag::UnaryRequest(cb) => cb.resolve(cq, success),
             CallTag::Abort(_) => {}
             CallTag::Shutdown(prom) => prom.resolve(success),
-            CallTag::Spawn(notify) => self::executor::resolve(notify, success),
+            CallTag::Spawn(notify) => self::executor::resolve(cq, notify, success),
         }
     }
 }

--- a/tests-and-examples/tests/cases/kick.rs
+++ b/tests-and-examples/tests/cases/kick.rs
@@ -108,3 +108,132 @@ fn spawn_chianed_channel(
 
     (tx1, rx2)
 }
+
+#[derive(Clone)]
+pub struct DeadLockService {
+    reporter: mpsc::Sender<()>,
+}
+
+impl Greeter for DeadLockService {
+    fn say_hello(
+        &mut self,
+        ctx: RpcContext<'_>,
+        mut req: HelloRequest,
+        sink: UnarySink<HelloReply>,
+    ) {
+        let chan = Arc::default();
+        let tx = NaiveSender { chan };
+        let rx = NaiveReceiver {
+            chan: tx.chan.clone(),
+        };
+        let name = req.take_name();
+        let reporter = self.reporter.clone();
+        ctx.spawn(
+            rx.map_err(|_| panic!("should receive message"))
+                .and_then(move |greet| {
+                    let mut resp = HelloReply::default();
+                    resp.set_message(format!("{} {}", greet, name));
+                    sink.success(resp)
+                        .map_err(|e| panic!("failed to reply {:?}", e))
+                        .map(move |_| {
+                            let _ = reporter.send(());
+                        })
+                }),
+        );
+        ctx.spawn(lazy(|| {
+            tx.send("hello".to_owned())
+                .map_err(|_| panic!("failed to send message"))
+        }));
+    }
+}
+
+#[derive(Default)]
+struct NaiveChannel<T> {
+    data: Option<T>,
+    task: Option<task::Task>,
+}
+
+struct NaiveSender<T> {
+    chan: Arc<Mutex<NaiveChannel<T>>>,
+}
+
+impl<T> NaiveSender<T> {
+    fn send(self, t: T) -> impl Future<Item = (), Error = ()> {
+        lazy(move || {
+            let timer = Instant::now();
+            while timer.elapsed() < Duration::from_secs(3) {
+                let mut chan = match self.chan.try_lock() {
+                    Ok(c) => c,
+                    Err(_) => continue,
+                };
+
+                chan.data = Some(t);
+                if let Some(t) = chan.task.take() {
+                    t.notify();
+                }
+                return Ok(());
+            }
+            panic!("failed to acquire lock for sender after 3 seconds.");
+        })
+    }
+}
+
+struct NaiveReceiver<T> {
+    chan: Arc<Mutex<NaiveChannel<T>>>,
+}
+
+impl<T> Future for NaiveReceiver<T> {
+    type Item = T;
+    type Error = ();
+
+    fn poll(&mut self) -> Poll<T, ()> {
+        let timer = Instant::now();
+        while timer.elapsed() < Duration::from_secs(3) {
+            let mut chan = match self.chan.try_lock() {
+                Ok(c) => c,
+                Err(_) => continue,
+            };
+            if let Some(t) = chan.data.take() {
+                return Ok(Async::Ready(t));
+            }
+            chan.task = Some(task::current());
+            return Ok(Async::NotReady);
+        }
+        panic!("failed to acquire lock for receiver after 3 seconds.");
+    }
+}
+
+/// Executor used to poll futures in place, which can cause deadlock.
+/// Following is the timeline:
+/// 1. receiver is polled and task is set.
+/// 2. sender acquires lock
+/// 3. sender sends data and notify task
+/// 4. executor poll futures in place, so notify will become polling receiver
+///    directly. So it acquires lock that is held by sender since 2, hence
+///    deadlock.
+#[test]
+fn test_deadlock() {
+    let env = Arc::new(EnvBuilder::new().build());
+    let (tx, rx) = mpsc::channel();
+    let service = create_greeter(DeadLockService { reporter: tx });
+    let mut server = ServerBuilder::new(env.clone())
+        .register_service(service)
+        .bind("127.0.0.1", 0)
+        .build()
+        .unwrap();
+    server.start();
+    let port = server.bind_addrs()[0].1;
+    let ch = ChannelBuilder::new(env).connect(&format!("127.0.0.1:{}", port));
+    let client = GreeterClient::new(ch);
+    let mut req = HelloRequest::default();
+    req.set_name("world".to_owned());
+    let f = client.say_hello_async(&req).unwrap();
+    if let Err(e) = rx.recv_timeout(Duration::from_secs(5)) {
+        // Panic will still calling drop method of server, which will wait for
+        // deadlock forever.
+        eprintln!("failed to wait for the case to finish: {:?}", e);
+        std::process::exit(1);
+    }
+    let reply = f.wait().expect("rpc");
+    assert_eq!(reply.get_message(), "hello world");
+}


### PR DESCRIPTION
grpcio executor polls futures in place to reduce context switch and for better locality coherence. But it can lead to deadlock. For example, sender and receiver can share memory which is guard by lock. Then deadlock can happen in following event sequences.

```
1. sender lock the shared memory
2.     sender put item into the shared memory
3.     sender notify
4.     grpcio exeuctor poll in place
5.     receiver woken up
6.     receiver lock the shared memory
7.        receiver poll item from shared
```

Step 6 will wait forever as the lock has been held by sender since step 1.

A better way to handle notification is store the readiness in a stack and handle the readiness one by one. Using stack instead of queue for better coherence.
