### PR TITLE
compiler: allow clippy all

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# grpcio-compiler 0.5.0-alpha.6 - 2019-11-13
+
+- Fix clippy warnings (#403)
+
 # 0.5.0-alpha.5 - 2019-11-05
 
 - Fix segment fault under race contention (#367)

--- a/compiler/Cargo.toml
+++ b/compiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grpcio-compiler"
-version = "0.5.0-alpha.5"
+version = "0.5.0-alpha.6"
 edition = "2018"
 authors = ["The TiKV Project Developers"]
 license = "Apache-2.0"
@@ -14,14 +14,14 @@ categories = ["network-programming"]
 [features]
 default = ["protobuf-codec"]
 protobuf-codec = []
-prost-codec = ["prost-build", "prost-types", "prost"]
+prost-codec = ["prost-build", "prost-types", "prost", "derive-new"]
 
 [dependencies]
 protobuf = "2"
 prost = { version = "0.5", optional = true }
 prost-build = { version = "0.5", optional = true }
 prost-types = { version = "0.5", optional = true }
-derive-new = "0.5"
+derive-new = { version = "0.5", optional = true }
 tempfile = "3.0"
 
 [[bin]]

--- a/compiler/src/codegen.rs
+++ b/compiler/src/codegen.rs
@@ -75,7 +75,7 @@ impl<'a> CodeWriter<'a> {
         self.write_line("");
         self.comment("https://github.com/Manishearth/rust-clippy/issues/702");
         self.write_line("#![allow(unknown_lints)]");
-        self.write_line("#![allow(clippy)]");
+        self.write_line("#![allow(clippy::all)]");
         self.write_line("");
         self.write_line("#![cfg_attr(rustfmt, rustfmt_skip)]");
         self.write_line("");


### PR DESCRIPTION
Clippy is deprecated. Should use `clippy::all` instead.