### PR TITLE
doc: make build_args and channel_args public

### DIFF
--- a/src/channel.rs
+++ b/src/channel.rs
@@ -431,9 +431,6 @@ impl ChannelBuilder {
     }
 
     /// Build `ChannelArgs` from the current configuration.
-    ///
-    /// This method is only for bench usage, users should use the encapsulated API instead.
-    #[doc(hidden)]
     #[allow(clippy::identity_conversion)]
     pub fn build_args(&self) -> ChannelArgs {
         let args = unsafe { grpc_sys::grpcwrap_channel_args_create(self.options.len()) };

--- a/src/server.rs
+++ b/src/server.rs
@@ -288,7 +288,6 @@ impl ServerBuilder {
     }
 
     /// Add additional configuration for each incoming channel.
-    #[doc(hidden)]
     pub fn channel_args(mut self, args: ChannelArgs) -> ServerBuilder {
         self.args = Some(args);
         self


### PR DESCRIPTION
Fixes https://github.com/tikv/grpc-rs/issues/399