### PR TITLE
shrink sink internal buffer if need

### DIFF
--- a/src/call/mod.rs
+++ b/src/call/mod.rs
@@ -4,7 +4,7 @@ pub mod client;
 pub mod server;
 
 use std::sync::Arc;
-use std::{cmp, ptr, slice};
+use std::{ptr, slice};
 
 use crate::cq::CompletionQueue;
 use crate::grpc_sys::{self, grpc_call, grpc_call_error, grpcwrap_batch_context};

--- a/src/call/mod.rs
+++ b/src/call/mod.rs
@@ -640,9 +640,8 @@ impl SinkBase {
                 .start_send_message(&self.buf, flags.flags, self.send_metadata)
         })?;
         // NOTE: Content of `self.buf` is copied into grpc internal.
-        if self.buf.capacity() > BUF_SHRINK_SIZE {
-            self.buf = Vec::with_capacity(BUF_SHRINK_SIZE);
-        }
+        self.buf.truncate(BUF_SHRINK_SIZE);
+        self.buf.shrink_to_fit();
         self.batch_f = Some(write_f);
         self.send_metadata = false;
         Ok(true)

--- a/src/call/mod.rs
+++ b/src/call/mod.rs
@@ -631,7 +631,6 @@ impl SinkBase {
 
         self.buf.clear();
         ser(t, &mut self.buf);
-
         if flags.get_buffer_hint() && self.send_metadata {
             // temporary fix: buffer hint with send meta will not send out any metadata.
             flags = flags.buffer_hint(false);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,7 @@ framework that puts mobile and HTTP/2 first. grpcio is built on [gRPC Core] and 
 #![allow(clippy::new_without_default)]
 #![allow(clippy::cast_lossless)]
 #![allow(clippy::option_map_unit_fn)]
+#![feature(shrink_to)]
 
 #[macro_use]
 extern crate futures;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,6 @@ framework that puts mobile and HTTP/2 first. grpcio is built on [gRPC Core] and 
 #![allow(clippy::new_without_default)]
 #![allow(clippy::cast_lossless)]
 #![allow(clippy::option_map_unit_fn)]
-#![feature(shrink_to)]
 
 #[macro_use]
 extern crate futures;


### PR DESCRIPTION
Signed-off-by: qupeng <qupeng@pingcap.com>

If there are too many long term connections, `SinkBase`'s internal buffer could take too much memory. We have located this problem in some situations. This PR shrinks its internal buffer.
Running test cases with the patch, TiKV won't report OOM, and its memory usage becomes stable.