### PR TITLE
reuse CallTag for streaming calls

### DIFF
--- a/src/env.rs
+++ b/src/env.rs
@@ -8,7 +8,7 @@ use std::thread::{Builder as ThreadBuilder, JoinHandle};
 use crate::grpc_sys;
 
 use crate::cq::{CompletionQueue, CompletionQueueHandle, EventType, WorkQueue};
-use crate::task::CallTag;
+use crate::task::{self, CallTag};
 
 // event loop
 fn poll_queue(tx: mpsc::Sender<CompletionQueue>) {
@@ -26,8 +26,7 @@ fn poll_queue(tx: mpsc::Sender<CompletionQueue>) {
         }
 
         let tag: Box<CallTag> = unsafe { Box::from_raw(e.tag as _) };
-
-        tag.resolve(&cq, e.success != 0);
+        task::resolve(tag, &cq, e.success != 0);
         while let Some(work) = unsafe { cq.worker.pop_work() } {
             work.finish(&cq);
         }

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -181,6 +181,7 @@ pub fn resolve(tag: Box<CallTag>, cq: &CompletionQueue, success: bool) {
     let raw = Box::into_raw(tag);
     if let CallTag::Batch(ref mut prom) = unsafe { &mut *raw } {
         if prom.resolve(success) {
+            // Return directly, skip to drop the `CallTag`.
             return;
         }
     }

--- a/src/task/promise.rs
+++ b/src/task/promise.rs
@@ -1,6 +1,7 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
 use std::fmt::{self, Debug, Formatter};
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 
 use super::Inner;
@@ -24,6 +25,7 @@ pub struct Batch {
     ty: BatchType,
     ctx: BatchContext,
     inner: Arc<Inner<Option<MessageReader>>>,
+    ref_count: AtomicUsize,
 }
 
 impl Batch {
@@ -32,6 +34,7 @@ impl Batch {
             ty,
             ctx: BatchContext::new(),
             inner,
+            ref_count: AtomicUsize::new(1),
         }
     }
 
@@ -99,13 +102,30 @@ impl Batch {
             }
             BatchType::Finish => {
                 self.finish_response(success);
+                return self.unref_batch();
             }
             BatchType::Read => {
                 self.read_one_msg(success);
-                return true;
+                return self.unref_batch();
             }
         }
         false
+    }
+
+    /// Ref the `Batch` before call `grpc_call_start_batch`.
+    pub fn ref_batch(&self) {
+        self.ref_count.fetch_add(1, Ordering::Release);
+    }
+
+    /// Return `true` means the tag can be reused.
+    pub fn unref_batch(&self) -> bool {
+        self.ref_count.fetch_sub(1, Ordering::AcqRel) > 1
+    }
+}
+
+impl Drop for Batch {
+    fn drop(&mut self) {
+        self.unref_batch();
     }
 }
 


### PR DESCRIPTION
This PR make CallTag reusable for streaming calls.

### Task list:
- [x] PR for implementation
- [ ] Benchmark result