### PR TITLE
*: use libz-sys instead of bundled one

### DIFF
--- a/grpc-sys/Cargo.toml
+++ b/grpc-sys/Cargo.toml
@@ -26,6 +26,7 @@ exclude = [
     "grpc/src/ruby/*",
     "grpc/vsprojects/*",
     "grpc/test/core/end2end/*",
+    "grpc/third_party/zlib/*",
     "grpc/third_party/abseil-cpp/*",
     "grpc/third_party/benchmark/*",
     "grpc/third_party/bloaty/*",
@@ -48,6 +49,7 @@ exclude = [
 [dependencies]
 libc = "0.2"
 openssl-sys = { version = "0.9", optional = true, features = ["vendored"] }
+libz-sys = { version = "1.0.25", features = ["static"] }
 
 [features]
 default = []

--- a/grpc-sys/build.rs
+++ b/grpc-sys/build.rs
@@ -41,7 +41,6 @@ fn probe_library(library: &str, cargo_metadata: bool) -> Library {
 fn prepare_grpc() {
     let mut modules = vec![
         "grpc",
-        "grpc/third_party/zlib",
         "grpc/third_party/cares/cares",
         "grpc/third_party/address_sorting",
     ];
@@ -77,7 +76,7 @@ fn trim_start<'a>(s: &'a str, prefix: &str) -> Option<&'a str> {
 fn build_grpc(cc: &mut Build, library: &str) {
     prepare_grpc();
 
-    let mut third_party = vec!["cares/cares/lib", "zlib"];
+    let mut third_party = vec!["cares/cares/lib"];
 
     let dst = {
         let mut config = Config::new("grpc");
@@ -151,21 +150,16 @@ fn build_grpc(cc: &mut Build, library: &str) {
         } else if cfg!(feature = "secure") {
             third_party.extend_from_slice(&["boringssl/ssl", "boringssl/crypto"]);
         }
+        // Uses zlib from libz-sys.
+        setup_libz(&mut config);
         config.build_target(library).uses_cxx11().build()
     };
 
-    let mut zlib = "z";
     let build_dir = format!("{}/build", dst.display());
     if get_env("CARGO_CFG_TARGET_OS").map_or(false, |s| s == "windows") {
         let profile = match &*env::var("PROFILE").unwrap_or("debug".to_owned()) {
-            "bench" | "release" => {
-                zlib = "zlibstatic";
-                "Release"
-            }
-            _ => {
-                zlib = "zlibstaticd";
-                "Debug"
-            }
+            "bench" | "release" => "Release",
+            _ => "Debug",
         };
         println!("cargo:rustc-link-search=native={}/{}", build_dir, profile);
         for path in third_party {
@@ -184,7 +178,7 @@ fn build_grpc(cc: &mut Build, library: &str) {
         }
     }
 
-    println!("cargo:rustc-link-lib=static={}", zlib);
+    println!("cargo:rustc-link-lib=static=z");
     println!("cargo:rustc-link-lib=static=cares");
     println!("cargo:rustc-link-lib=static=gpr");
     println!("cargo:rustc-link-lib=static=address_sorting");
@@ -229,6 +223,21 @@ fn figure_ssl_path(build_dir: &str) {
     }
     println!("cargo:rustc-link-lib=ssl");
     println!("cargo:rustc-link-lib=crypto");
+}
+
+fn setup_libz(config: &mut Config) {
+    config.define("gRPC_ZLIB_PROVIDER", "package");
+    config.register_dep("Z");
+    // cmake script expect libz.a being under ${DEP_Z_ROOT}/lib, but libz-sys crate put it
+    // under ${DEP_Z_ROOT}/build. Append the path to CMAKE_PREFIX_PATH to get around it.
+    env::set_var("CMAKE_PREFIX_PATH", {
+        let zlib_path = format!("{}/build", env::var("DEP_Z_ROOT").unwrap());
+        if let Ok(prefix_path) = env::var("CMAKE_PREFIX_PATH") {
+            format!("{};{}", prefix_path, zlib_path)
+        } else {
+            zlib_path
+        }
+    });
 }
 
 #[cfg(feature = "openssl-vendored")]

--- a/scripts/reset-submodule
+++ b/scripts/reset-submodule
@@ -3,7 +3,6 @@ git submodule update --init grpc-sys/grpc
 cd grpc-sys/grpc
 git submodule update --init third_party/boringssl
 git submodule update --init third_party/cares/cares
-git submodule update --init third_party/zlib
 cd third_party/zlib
 git clean -f
 git reset --hard

--- a/src/async/executor.rs
+++ b/src/async/executor.rs
@@ -117,7 +117,7 @@ impl SpawnNotify {
     pub fn resolve(self, success: bool) {
         // it should always be canceled for now.
         assert!(success);
-        poll(&Arc::new(self.clone()), true);
+        poll(&Arc::new(self), true);
     }
 }
 


### PR DESCRIPTION
When using the built-in cmake to build zlib, it changes the source tree
as madler/zlib#162 describes. This leads to the failure during
[generating the docs][1]. So let's switch to libz-sys instead, which
uses its own custom script to build zlib, and leave source tree as it
is. Switching to libz-sys can also reduce the package size as we can
ignore more sub modules. It should improve compile time if libz-sys is
also a dependency of other crates.

The only shortcoming is that libz-sys may not be compatible with
grpcio, but I believe the chance is quite small given it's such a small
library. And giving it's such a small library, the benifits like compile
time or package size described above may be too small to be observed.

[1]: https://docs.rs/crate/grpcio/0.5.0-alpha.5/builds/196235.