### PR TITLE
Add `Eq` to `RpcStatusCode` to allow use in pattern matching

### DIFF
--- a/src/call/mod.rs
+++ b/src/call/mod.rs
@@ -22,7 +22,7 @@ const BUF_SHRINK_SIZE: usize = 4 * 1024;
 
 /// An gRPC status code structure.
 /// This type contains constants for all gRPC status codes.
-#[derive(PartialEq, Clone, Copy, Debug)]
+#[derive(PartialEq, Eq, Clone, Copy, Debug)]
 pub struct RpcStatusCode(i32);
 
 impl From<i32> for RpcStatusCode {


### PR DESCRIPTION
Current implementation respects the rules of [`Eq`](https://doc.rust-lang.org/std/cmp/trait.Eq.html).

Current missing derive prevents use in pattern matching:
```
to use a constant of type `grpcio::call::RpcStatusCode` in a pattern, `grpcio::call::RpcStatusCode` must be annotated with `#[derive(PartialEq, Eq)]`
```