### PR TITLE
grpc-sys: downgrade bindgen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-# 0.5.1 - 2020-03-20
+# grpcio-sys 0.5.2 - 2020-03-31
+
+- Downgrade bindgen version to be backward compatible. (#452)
+
+# 0.5.1 - 2020-03-30
 
 - Clarify load balancing status (#445)
 - Support unix domain socket (#446)

--- a/grpc-sys/Cargo.toml
+++ b/grpc-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grpcio-sys"
-version = "0.5.1"
+version = "0.5.2"
 authors = ["The TiKV Project Developers"]
 license = "Apache-2.0"
 keywords = ["grpc", "bindings"]
@@ -70,4 +70,5 @@ cc = "1.0"
 cmake = "0.1.40"
 pkg-config = "0.3"
 walkdir = "2.2.9"
-bindgen = { version = "0.53.2", default-features = false, features = ["runtime"] }
+# Because of rust-lang/cargo#5237, bindgen should not be upgraded util a minor or major release.
+bindgen = { version = "0.51.0", default-features = false }

--- a/grpc-sys/build.rs
+++ b/grpc-sys/build.rs
@@ -299,7 +299,6 @@ fn bindgen_grpc(mut config: bindgen::Builder, file_path: &PathBuf) {
         .clang_arg("-std=c++11")
         .rustfmt_bindings(true)
         .impl_debug(true)
-        .size_t_is_usize(true)
         .whitelist_function(r"\bgrpc_.*")
         .whitelist_function(r"\bgpr_.*")
         .whitelist_function(r"\bgrpcwrap_.*")


### PR DESCRIPTION
Due to rust-lang/cargo#5237, upgrading bindgen is not backward
compatible.