### PR TITLE
Enable ALPN as default

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ grpcio = { version = "0.4", default-features = false, features = ["protobuf-code
 instead of OpenSSL. This may cause linking issues due to symbol clashes and/or
 missing symbols when another one of your dependencies uses OpenSSL. To resolve
 this, you can tell `gRPC-rs` to use OpenSSL too by specifying `"openssl"` in
-your `Cargo.toml`'s features list for `gprcio`. E.g.:
+your `Cargo.toml`'s features list for `gprcio`, which requires openssl (>=1.0.2). E.g.:
 
 ```toml
 [dependencies]

--- a/grpc-sys/build.rs
+++ b/grpc-sys/build.rs
@@ -130,17 +130,6 @@ fn build_grpc(cc: &mut Build, library: &str) {
         if cfg!(feature = "openssl") {
             config.define("gRPC_SSL_PROVIDER", "package");
             config.define("EMBED_OPENSSL", "false");
-            // check if openssl provided from system support ALPN
-            if !cfg!(feature = "openssl-vendored")
-                && Build::new()
-                    .file("grpc/test/build/openssl-alpn.c")
-                    .cargo_metadata(false)
-                    .cpp(true)
-                    .try_compile("check_alpn")
-                    .is_err()
-            {
-                config.cxxflag("-DTSI_OPENSSL_ALPN_SUPPORT=0");
-            }
             setup_openssl(&mut config)
         } else if cfg!(feature = "secure") {
             third_party.extend_from_slice(&["boringssl/ssl", "boringssl/crypto"]);
@@ -261,7 +250,18 @@ fn setup_openssl(config: &mut Config) {
 }
 
 #[cfg(not(feature = "openssl-vendored"))]
-fn setup_openssl(_config: &mut Config) {}
+fn setup_openssl(config: &mut Config) {
+    // check if openssl provided from system support ALPN
+    if Build::new()
+        .file("grpc/test/build/openssl-alpn.c")
+        .cargo_metadata(false)
+        .cpp(true)
+        .try_compile("check_alpn")
+        .is_err()
+    {
+        config.cxxflag("-DTSI_OPENSSL_ALPN_SUPPORT=0");
+    }
+}
 
 fn get_env(name: &str) -> Option<String> {
     println!("cargo:rerun-if-env-changed={}", name);

--- a/grpc-sys/build.rs
+++ b/grpc-sys/build.rs
@@ -130,10 +130,6 @@ fn build_grpc(cc: &mut Build, library: &str) {
         if cfg!(feature = "openssl") {
             config.define("gRPC_SSL_PROVIDER", "package");
             config.define("EMBED_OPENSSL", "false");
-            // Problem is: Ubuntu Trusty shipped with openssl 1.0.1f. Which doesn't
-            // support alpn. And Google's gRPC checks for support of ALPN in plane
-            // old Makefile, but not in CMake.
-            config.cxxflag("-DTSI_OPENSSL_ALPN_SUPPORT=0");
             setup_openssl(&mut config)
         } else if cfg!(feature = "secure") {
             third_party.extend_from_slice(&["boringssl/ssl", "boringssl/crypto"]);

--- a/grpc-sys/build.rs
+++ b/grpc-sys/build.rs
@@ -130,6 +130,17 @@ fn build_grpc(cc: &mut Build, library: &str) {
         if cfg!(feature = "openssl") {
             config.define("gRPC_SSL_PROVIDER", "package");
             config.define("EMBED_OPENSSL", "false");
+            // check if openssl provided from system support ALPN
+            if !cfg!(feature = "openssl-vendored")
+                && Build::new()
+                    .file("grpc/test/build/openssl-alpn.c")
+                    .cargo_metadata(false)
+                    .cpp(true)
+                    .try_compile("check_alpn")
+                    .is_err()
+            {
+                config.cxxflag("-DTSI_OPENSSL_ALPN_SUPPORT=0");
+            }
             setup_openssl(&mut config)
         } else if cfg!(feature = "secure") {
             third_party.extend_from_slice(&["boringssl/ssl", "boringssl/crypto"]);


### PR DESCRIPTION
NPN, the Next Protocol Negotiation extension, is specified by [a draft expired 6 years ago](https://tools.ietf.org/html/draft-agl-tls-nextprotoneg-04) and has been replaced by ALPN. So I suggest that we should support its successor ALPN to ensure successful connection to the servers with ALPN only.

Signed-off-by: TXXT <hunterlxt@live.com>