### PR TITLE
Fetch google.rpc.Status proto if present

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -38,7 +38,7 @@ pub enum Error {
 impl fmt::Display for Error {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Error::RpcFailure(RpcStatus { status, details }) => match details {
+            Error::RpcFailure(RpcStatus { status, details, .. }) => match details {
                 Some(details) => write!(fmt, "RpcFailure: {} {}", status, details),
                 None => write!(fmt, "RpcFailure: {}", status),
             },


### PR DESCRIPTION
This allows us to get metadata from the server around _why_ a failure
happened.

We've been using this patch in an older version of the `grpcio` crate (https://github.com/pantsbuild/grpc-rs/commit/4dfafe9355dc996d7d0702e7386a6fedcd9734c0) for a while now to enable handling "both rpc status errors as well as message-inline errors" (see https://github.com/pantsbuild/pants/pull/6589).