### PR TITLE
Enhance sinks to make them batchable

### DIFF
--- a/benchmark/src/bench.rs
+++ b/benchmark/src/bench.rs
@@ -61,15 +61,8 @@ impl BenchmarkService for Benchmark {
         sink: ClientStreamingSink<SimpleResponse>,
     ) {
         let f = async move {
-            let mut req = SimpleRequest::default();
-            while let Some(r) = stream.try_next().await? {
-                req = r;
-            }
-            if req.get_response_size() > 0 {
-                sink.success(gen_resp(&req)).await?;
-            } else {
-                sink.success(Default::default()).await?;
-            }
+            let _sink = sink;
+            while stream.try_next().await?.is_some() {}
             Ok(())
         };
         let keep_running = self.keep_running.clone();

--- a/benchmark/src/bench.rs
+++ b/benchmark/src/bench.rs
@@ -61,8 +61,11 @@ impl BenchmarkService for Benchmark {
         sink: ClientStreamingSink<SimpleResponse>,
     ) {
         let f = async move {
-            let _sink = sink;
-            while stream.try_next().await?.is_some() {}
+            let mut req = SimpleRequest::default();
+            while let Some(r) = stream.try_next().await? {
+                req = r;
+            }
+            sink.success(gen_resp(&req));
             Ok(())
         };
         let keep_running = self.keep_running.clone();

--- a/benchmark/src/bench.rs
+++ b/benchmark/src/bench.rs
@@ -61,13 +61,13 @@ impl BenchmarkService for Benchmark {
         sink: ClientStreamingSink<SimpleResponse>,
     ) {
         let f = async move {
-            let mut resp: Option<SimpleResponse> = None;
-            while let Some(req) = stream.try_next().await? {
-                if resp.is_none() {
-                    resp = Some(gen_resp(&req));
-                }
+            let mut req = SimpleRequest::default();
+            while let Some(r) = stream.try_next().await? {
+                req = r;
             }
-            sink.success(resp.unwrap()).await?;
+            if req.get_response_size() > 0 {
+                sink.success(gen_resp(&req)).await?;
+            }
             Ok(())
         };
         let keep_running = self.keep_running.clone();

--- a/benchmark/src/bench.rs
+++ b/benchmark/src/bench.rs
@@ -67,6 +67,8 @@ impl BenchmarkService for Benchmark {
             }
             if req.get_response_size() > 0 {
                 sink.success(gen_resp(&req)).await?;
+            } else {
+                sink.success(Default::default()).await?;
             }
             Ok(())
         };

--- a/benchmark/src/client.rs
+++ b/benchmark/src/client.rs
@@ -261,7 +261,7 @@ impl<B: Backoff + Send + 'static> RequestExecutor<B> {
         let keep_running = self.ctx.keep_running.clone();
 
         let f = async move {
-            let (mut sender, _) = self.client.streaming_from_client().unwrap();
+            let (mut sender, _receiver) = self.client.streaming_from_client().unwrap();
 
             let send_stream = Box::pin(stream::unfold(
                 (self, Instant::now()),

--- a/src/call/client.rs
+++ b/src/call/client.rs
@@ -334,8 +334,9 @@ impl<Req> StreamingCallSink<Req> {
     /// By default the sink works in normal mode, that is, `start_send` always starts to send message
     /// immediately. But when the `enhance_batch` is enabled, the stream will be batched together as
     /// much as possible. The specific rule is listed below:
-    /// Set the `buffer_hint` of the non-end message in the stream to true, and set the `buffer_hint` of
-    /// the last message to false in `poll_flush`, so that the previously bufferd messages will be sent out.
+    /// Set the `buffer_hint` of the non-end message in the stream to true. And set the `buffer_hint`
+    /// of the last message to false in `poll_flush` only when there is at least one message with the
+    /// `buffer_hint` false, so that the previously bufferd messages will be sent out.
     pub fn enhance_batch(&mut self, flag: bool) {
         self.sink_base.enhance_buffer_strategy = flag;
     }

--- a/src/call/client.rs
+++ b/src/call/client.rs
@@ -331,6 +331,10 @@ impl<Req> StreamingCallSink<Req> {
         }
     }
 
+    pub fn enable_batch(&mut self, flag: bool) {
+        self.sink_base.enable_batch = flag;
+    }
+
     pub fn cancel(&mut self) {
         let call = self.call.lock();
         call.call.cancel()

--- a/src/call/client.rs
+++ b/src/call/client.rs
@@ -373,7 +373,8 @@ impl<Req> Sink<(Req, WriteFlags)> for StreamingCallSink<Req> {
             let mut call = self.call.lock();
             call.check_alive()?;
         }
-        Pin::new(&mut self.sink_base).poll_ready(cx)
+        let t = &mut *self;
+        Pin::new(&mut t.sink_base).poll_flush(cx, &mut t.call)
     }
 
     fn poll_close(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Result<()>> {

--- a/src/call/client.rs
+++ b/src/call/client.rs
@@ -331,8 +331,8 @@ impl<Req> StreamingCallSink<Req> {
         }
     }
 
-    pub fn enable_batch(&mut self, flag: bool) {
-        self.sink_base.enable_batch = flag;
+    pub fn enhance_batch(&mut self, flag: bool) {
+        self.sink_base.enhance_buffer_strategy = flag;
     }
 
     pub fn cancel(&mut self) {

--- a/src/call/client.rs
+++ b/src/call/client.rs
@@ -333,7 +333,7 @@ impl<Req> StreamingCallSink<Req> {
 
     /// By default the sink works in normal mode, that is, `start_send` always starts to send message
     /// immediately. But when the `enhance_batch` is enabled, the stream will be batched together as
-    /// much as possible. The specific rule is listed below:
+    /// much as possible. The specific rules are listed below:
     /// Set the `buffer_hint` of the non-end message in the stream to true. And set the `buffer_hint`
     /// of the last message to false in `poll_flush` only when there is at least one message with the
     /// `buffer_hint` false, so that the previously bufferd messages will be sent out.

--- a/src/call/client.rs
+++ b/src/call/client.rs
@@ -331,12 +331,15 @@ impl<Req> StreamingCallSink<Req> {
         }
     }
 
-    /// By default the sink works in normal mode, that is, `start_send` always starts to send message
-    /// immediately. But when the `enhance_batch` is enabled, the stream will be batched together as
-    /// much as possible. The specific rules are listed below:
-    /// Set the `buffer_hint` of the non-end message in the stream to true. And set the `buffer_hint`
-    /// of the last message to false in `poll_flush` only when there is at least one message with the
-    /// `buffer_hint` false, so that the previously bufferd messages will be sent out.
+    /// By default it always sends messages with their configured buffer hint. But when the
+    /// `enhance_batch` is enabled, messages will be batched together as many as possible.
+    /// The rules are listed as below:
+    /// - All messages except the last one will be sent with `buffer_hint` set to true.
+    /// - The last message will also be sent with `buffer_hint` set to true unless any message is
+    ///    offered with buffer hint set to false.
+    ///
+    /// No matter `enhance_batch` is true or false, it's recommended to follow the contract of
+    /// Sink and call `poll_flush` to ensure messages are handled by gRPC C Core.
     pub fn enhance_batch(&mut self, flag: bool) {
         self.sink_base.enhance_buffer_strategy = flag;
     }

--- a/src/call/client.rs
+++ b/src/call/client.rs
@@ -331,6 +331,11 @@ impl<Req> StreamingCallSink<Req> {
         }
     }
 
+    /// By default the sink works in normal mode, that is, `start_send` always starts to send message
+    /// immediately. But when the `enhance_batch` is enabled, the stream will be batched together as
+    /// much as possible. The specific rule is listed below:
+    /// Set the `buffer_hint` of the non-end message in the stream to true, and set the `buffer_hint` of
+    /// the last message to false in `poll_flush`, so that the previously bufferd messages will be sent out.
     pub fn enhance_batch(&mut self, flag: bool) {
         self.sink_base.enhance_buffer_strategy = flag;
     }

--- a/src/call/mod.rs
+++ b/src/call/mod.rs
@@ -628,11 +628,11 @@ impl WriteFlags {
 
 /// A helper struct for constructing Sink object for batch requests.
 ///
-/// The sink works in normal mode by default, that is, `start_send` always sends message immediately.
-/// But when the `enhance_buffer_strategy` is enabled, the message to be sent will be processed
-/// according to the following process:
-/// Set the `buffer_hint` of the non-end message in the stream to true, and set the `buffer_hint` of the
-/// last message to true in `poll_flush`, so that the previously bufferd messages will be sent out.
+/// By default the sink works in normal mode, that is, `start_send` always starts to send message
+/// immediately. But when the `enhance_buffer_strategy` is enabled, the stream will be batched
+/// together as much as possible. The specific rule is listed below:
+/// Set the `buffer_hint` of the non-end message in the stream to true, and set the `buffer_hint` of
+/// the last message to false in `poll_flush`, so that the previously bufferd messages will be sent out.
 struct SinkBase {
     // Batch job to be executed in `poll_ready`.
     batch_f: Option<BatchFuture>,

--- a/src/call/mod.rs
+++ b/src/call/mod.rs
@@ -737,10 +737,11 @@ impl SinkBase {
         self.batch_f = Some(write_f);
         self.buf_flags.take();
         // NOTE: Content of `self.buf` is copied into grpc internal.
-        self.buffer.clear();
         if self.buffer.capacity() > BUF_SHRINK_SIZE {
+            self.buffer.truncate(BUF_SHRINK_SIZE);
             self.buffer.shrink_to_fit();
         }
+        self.buffer.clear();
         Ok(())
     }
 }

--- a/src/call/mod.rs
+++ b/src/call/mod.rs
@@ -616,12 +616,12 @@ impl WriteFlags {
     }
 
     /// Get whether buffer hint is enabled.
-    pub fn get_buffer_hint(&self) -> bool {
+    pub fn get_buffer_hint(self) -> bool {
         (self.flags & grpc_sys::GRPC_WRITE_BUFFER_HINT) != 0
     }
 
     /// Get whether compression is disabled.
-    pub fn get_force_no_compress(&self) -> bool {
+    pub fn get_force_no_compress(self) -> bool {
         (self.flags & grpc_sys::GRPC_WRITE_NO_COMPRESS) != 0
     }
 }

--- a/src/call/mod.rs
+++ b/src/call/mod.rs
@@ -631,8 +631,9 @@ impl WriteFlags {
 /// By default the sink works in normal mode, that is, `start_send` always starts to send message
 /// immediately. But when the `enhance_buffer_strategy` is enabled, the stream will be batched
 /// together as much as possible. The specific rule is listed below:
-/// Set the `buffer_hint` of the non-end message in the stream to true, and set the `buffer_hint` of
-/// the last message to false in `poll_flush`, so that the previously bufferd messages will be sent out.
+/// Set the `buffer_hint` of the non-end message in the stream to true. And set the `buffer_hint`
+/// of the last message to false in `poll_flush` only when there is at least one message with the
+/// `buffer_hint` false, so that the previously bufferd messages will be sent out.
 struct SinkBase {
     // Batch job to be executed in `poll_ready`.
     batch_f: Option<BatchFuture>,

--- a/src/call/mod.rs
+++ b/src/call/mod.rs
@@ -716,6 +716,7 @@ impl SinkBase {
             self.start_send_buffer_message(self.last_buf_hint, call)?;
             ready!(self.poll_ready(cx)?);
         }
+        self.last_buf_hint = true;
         Poll::Ready(Ok(()))
     }
 

--- a/src/call/server.rs
+++ b/src/call/server.rs
@@ -426,7 +426,7 @@ macro_rules! impl_stream_sink {
 
             /// By default the sink works in normal mode, that is, `start_send` always starts to send message
             /// immediately. But when the `enhance_batch` is enabled, the stream will be batched together as
-            /// much as possible. The specific rule is listed below:
+            /// much as possible. The specific rules are listed below:
             /// Set the `buffer_hint` of the non-end message in the stream to true. And set the `buffer_hint`
             /// of the last message to false in `poll_flush` only when there is at least one message with the
             /// `buffer_hint` false, so that the previously bufferd messages will be sent out.

--- a/src/call/server.rs
+++ b/src/call/server.rs
@@ -427,8 +427,9 @@ macro_rules! impl_stream_sink {
             /// By default the sink works in normal mode, that is, `start_send` always starts to send message
             /// immediately. But when the `enhance_batch` is enabled, the stream will be batched together as
             /// much as possible. The specific rule is listed below:
-            /// Set the `buffer_hint` of the non-end message in the stream to true, and set the `buffer_hint` of
-            /// the last message to false in `poll_flush`, so that the previously bufferd messages will be sent out.
+            /// Set the `buffer_hint` of the non-end message in the stream to true. And set the `buffer_hint`
+            /// of the last message to false in `poll_flush` only when there is at least one message with the
+            /// `buffer_hint` false, so that the previously bufferd messages will be sent out.
             pub fn enhance_batch(&mut self, flag: bool) {
                 self.base.enhance_buffer_strategy = flag;
             }

--- a/src/call/server.rs
+++ b/src/call/server.rs
@@ -424,6 +424,11 @@ macro_rules! impl_stream_sink {
                 }
             }
 
+            /// By default the sink works in normal mode, that is, `start_send` always starts to send message
+            /// immediately. But when the `enhance_batch` is enabled, the stream will be batched together as
+            /// much as possible. The specific rule is listed below:
+            /// Set the `buffer_hint` of the non-end message in the stream to true, and set the `buffer_hint` of
+            /// the last message to false in `poll_flush`, so that the previously bufferd messages will be sent out.
             pub fn enhance_batch(&mut self, flag: bool) {
                 self.base.enhance_buffer_strategy = flag;
             }

--- a/src/call/server.rs
+++ b/src/call/server.rs
@@ -424,6 +424,10 @@ macro_rules! impl_stream_sink {
                 }
             }
 
+            pub fn enable_batch(&mut self, flag: bool) {
+                self.base.enable_batch = flag;
+            }
+
             pub fn set_status(&mut self, status: RpcStatus) {
                 assert!(self.flush_f.is_none());
                 self.status = status;

--- a/src/call/server.rs
+++ b/src/call/server.rs
@@ -424,12 +424,15 @@ macro_rules! impl_stream_sink {
                 }
             }
 
-            /// By default the sink works in normal mode, that is, `start_send` always starts to send message
-            /// immediately. But when the `enhance_batch` is enabled, the stream will be batched together as
-            /// much as possible. The specific rules are listed below:
-            /// Set the `buffer_hint` of the non-end message in the stream to true. And set the `buffer_hint`
-            /// of the last message to false in `poll_flush` only when there is at least one message with the
-            /// `buffer_hint` false, so that the previously bufferd messages will be sent out.
+            /// By default it always sends messages with their configured buffer hint. But when the
+            /// `enhance_batch` is enabled, messages will be batched together as many as possible.
+            /// The rules are listed as below:
+            /// - All messages except the last one will be sent with `buffer_hint` set to true.
+            /// - The last message will also be sent with `buffer_hint` set to true unless all messages are
+            ///    offered with buffer hint set to true.
+            ///
+            /// No matter `enhance_batch` is true or false, it's recommended to follow the contract of
+            /// Sink and call `poll_flush` to ensure messages are handled by gRPC C Core.
             pub fn enhance_batch(&mut self, flag: bool) {
                 self.base.enhance_buffer_strategy = flag;
             }

--- a/src/call/server.rs
+++ b/src/call/server.rs
@@ -428,8 +428,8 @@ macro_rules! impl_stream_sink {
             /// `enhance_batch` is enabled, messages will be batched together as many as possible.
             /// The rules are listed as below:
             /// - All messages except the last one will be sent with `buffer_hint` set to true.
-            /// - The last message will also be sent with `buffer_hint` set to true unless all messages are
-            ///    offered with buffer hint set to true.
+            /// - The last message will also be sent with `buffer_hint` set to true unless any message is
+            ///    offered with buffer hint set to false.
             ///
             /// No matter `enhance_batch` is true or false, it's recommended to follow the contract of
             /// Sink and call `poll_flush` to ensure messages are handled by gRPC C Core.

--- a/src/call/server.rs
+++ b/src/call/server.rs
@@ -487,7 +487,8 @@ macro_rules! impl_stream_sink {
                 if let Poll::Ready(_) = self.call.as_mut().unwrap().call(|c| c.poll_finish(cx))? {
                     return Poll::Ready(Err(Error::RemoteStopped));
                 }
-                Pin::new(&mut self.base).poll_ready(cx)
+                let t = &mut *self;
+                Pin::new(&mut t.base).poll_flush(cx, t.call.as_mut().unwrap())
             }
 
             fn poll_close(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Result<()>> {

--- a/src/call/server.rs
+++ b/src/call/server.rs
@@ -424,8 +424,8 @@ macro_rules! impl_stream_sink {
                 }
             }
 
-            pub fn enable_batch(&mut self, flag: bool) {
-                self.base.enable_batch = flag;
+            pub fn enhance_batch(&mut self, flag: bool) {
+                self.base.enhance_buffer_strategy = flag;
             }
 
             pub fn set_status(&mut self, status: RpcStatus) {

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -391,7 +391,7 @@ impl ChannelBuilder {
     }
 
     /// Build `ChannelArgs` from the current configuration.
-    #[allow(clippy::identity_conversion)]
+    #[allow(clippy::useless_conversion)]
     pub fn build_args(&self) -> ChannelArgs {
         let args = unsafe { grpc_sys::grpcwrap_channel_args_create(self.options.len()) };
         for (i, (k, v)) in self.options.iter().enumerate() {

--- a/tests-and-examples/Cargo.toml
+++ b/tests-and-examples/Cargo.toml
@@ -13,7 +13,7 @@ prost-codec = ["prost", "bytes", "grpcio/prost-codec", "grpcio-proto/prost-codec
 [dependencies]
 grpcio-sys = { path = "../grpc-sys", version = "0.6.0" }
 libc = "0.2"
-futures = "0.3"
+futures = { version = "0.3", features = ["thread-pool"] }
 protobuf = { version = "2.0", optional = true }
 prost = { version = "0.6", optional = true }
 bytes = { version = "0.5", optional = true }

--- a/tests-and-examples/Cargo.toml
+++ b/tests-and-examples/Cargo.toml
@@ -13,7 +13,8 @@ prost-codec = ["prost", "bytes", "grpcio/prost-codec", "grpcio-proto/prost-codec
 [dependencies]
 grpcio-sys = { path = "../grpc-sys", version = "0.6.0" }
 libc = "0.2"
-futures = { version = "0.3", features = ["thread-pool"] }
+futures = "0.3"
+futures-timer = "3.0"
 protobuf = { version = "2.0", optional = true }
 prost = { version = "0.6", optional = true }
 bytes = { version = "0.5", optional = true }

--- a/tests-and-examples/tests/cases/mod.rs
+++ b/tests-and-examples/tests/cases/mod.rs
@@ -7,3 +7,4 @@ mod health_check;
 mod kick;
 mod metadata;
 mod misc;
+mod stream;

--- a/tests-and-examples/tests/cases/stream.rs
+++ b/tests-and-examples/tests/cases/stream.rs
@@ -1,0 +1,126 @@
+// Copyright 2020 TiKV Project Authors. Licensed under Apache-2.0.
+
+use std::sync::Arc;
+
+use futures::executor::block_on;
+use futures::prelude::*;
+use futures::sink::SinkExt;
+use grpcio::{
+    ChannelBuilder, ClientStreamingSink, DuplexSink, EnvBuilder, RequestStream, RpcContext,
+    ServerBuilder, ServerStreamingSink, UnarySink, WriteFlags,
+};
+use grpcio_proto::example::route_guide::*;
+
+#[derive(Clone)]
+struct RouteGuideService {}
+
+impl RouteGuide for RouteGuideService {
+    fn get_feature(&mut self, _: RpcContext<'_>, _: Point, _: UnarySink<Feature>) {
+        unimplemented!()
+    }
+    fn list_features(&mut self, _: RpcContext<'_>, _: Rectangle, _: ServerStreamingSink<Feature>) {
+        unimplemented!()
+    }
+    fn record_route(
+        &mut self,
+        ctx: RpcContext<'_>,
+        mut points: RequestStream<Point>,
+        resp: ClientStreamingSink<RouteSummary>,
+    ) {
+        let f = async move {
+            let mut summary = RouteSummary::default();
+            let mut current_num = 0;
+            while let Some(point) = points.try_next().await? {
+                assert_eq!(
+                    point.get_longitude(),
+                    current_num,
+                    "messages sequence is wrong"
+                );
+                current_num += 1;
+                summary.point_count += 1;
+            }
+            resp.success(summary).await?;
+            Ok(())
+        }
+        .map_err(|_: grpcio::Error| panic!("server got error"))
+        .map(|_| ());
+        ctx.spawn(f)
+    }
+
+    fn route_chat(
+        &mut self,
+        _: RpcContext<'_>,
+        _: RequestStream<RouteNote>,
+        _: DuplexSink<RouteNote>,
+    ) {
+        unimplemented!()
+    }
+}
+
+#[test]
+fn test_client_send_all() {
+    let env = Arc::new(EnvBuilder::new().build());
+    let service = create_route_guide(RouteGuideService {});
+    let mut server = ServerBuilder::new(env.clone())
+        .register_service(service)
+        .bind("127.0.0.1", 0)
+        .build()
+        .unwrap();
+    server.start();
+    let port = server.bind_addrs().next().unwrap().1;
+    let ch = ChannelBuilder::new(env).connect(&format!("127.0.0.1:{}", port));
+    let client = RouteGuideClient::new(ch);
+
+    let exec_test_f = async move {
+        // test for send all
+        let (mut sink, receiver) = client.record_route().unwrap();
+        let mut send_data = vec![];
+        for i in 0..3000 {
+            let mut p = Point::default();
+            p.set_longitude(i);
+            send_data.push(p);
+        }
+        let send_stream = futures::stream::iter(send_data);
+        sink.send_all(&mut send_stream.map(move |item| Ok((item, WriteFlags::default()))))
+            .await
+            .unwrap();
+        sink.close().await.unwrap();
+        let summary = receiver.await.unwrap();
+        assert_eq!(summary.get_point_count(), 3000);
+        // test for send all enable batch
+        let (mut sink, receiver) = client.record_route().unwrap();
+        let mut send_data = vec![];
+        for i in 0..3000 {
+            let mut p = Point::default();
+            p.set_longitude(i);
+            send_data.push(p);
+        }
+        let send_stream = futures::stream::iter(send_data);
+        sink.enhance_batch(true);
+        sink.send_all(&mut send_stream.map(move |item| Ok((item, WriteFlags::default()))))
+            .await
+            .unwrap();
+        sink.close().await.unwrap();
+        let summary = receiver.await.unwrap();
+        assert_eq!(summary.get_point_count(), 3000);
+        // test for send all and buffer hint is true
+        let (mut sink, receiver) = client.record_route().unwrap();
+        let mut send_data = vec![];
+        for i in 0..3000 {
+            let mut p = Point::default();
+            p.set_longitude(i);
+            send_data.push(p);
+        }
+        let send_stream = futures::stream::iter(send_data);
+        sink.enhance_batch(false);
+        sink.send_all(
+            &mut send_stream.map(move |item| Ok((item, WriteFlags::default().buffer_hint(true)))),
+        )
+        .await
+        .unwrap();
+        sink.close().await.unwrap();
+        let summary = receiver.await.unwrap();
+        assert_eq!(summary.get_point_count(), 3000);
+    };
+    block_on(exec_test_f);
+}

--- a/tests-and-examples/tests/cases/stream.rs
+++ b/tests-and-examples/tests/cases/stream.rs
@@ -49,6 +49,9 @@ impl RouteGuide for RouteGuideService {
                     break;
                 }
             }
+            // Sleep a while to avoid the possibility that the client will receive
+            // remotestopped error.
+            std::thread::sleep(std::time::Duration::from_millis(100));
             resp.success(summary).await?;
             Ok(())
         }

--- a/tests-and-examples/tests/cases/stream.rs
+++ b/tests-and-examples/tests/cases/stream.rs
@@ -86,76 +86,67 @@ fn test_client_send_all() {
 
     let exec_test_f = async move {
         // Test for send all disable batch
-        {
-            let (mut sink, receiver) = client.record_route().unwrap();
-            let mut send_data = vec![];
-            for i in 0..MESSAGE_NUM {
-                let mut p = Point::default();
-                p.set_longitude(i);
-                send_data.push(p);
-            }
-            let send_stream = futures::stream::iter(send_data);
-            sink.send_all(&mut send_stream.map(move |item| Ok((item, WriteFlags::default()))))
-                .await
-                .unwrap();
-            let summary = receiver.await.unwrap();
-            assert_eq!(summary.get_point_count(), MESSAGE_NUM);
+        let (mut sink, receiver) = client.record_route().unwrap();
+        let mut send_data = vec![];
+        for i in 0..MESSAGE_NUM {
+            let mut p = Point::default();
+            p.set_longitude(i);
+            send_data.push(p);
         }
-
-        // Test for send all enable batch
-        {
-            let (mut sink, receiver) = client.record_route().unwrap();
-            let mut send_data = vec![];
-            for i in 0..MESSAGE_NUM {
-                let mut p = Point::default();
-                p.set_longitude(i);
-                send_data.push(p);
-            }
-            let send_stream = futures::stream::iter(send_data);
-            sink.enhance_batch(true);
-            sink.send_all(&mut send_stream.map(move |item| Ok((item, WriteFlags::default()))))
-                .await
-                .unwrap();
-            let summary = receiver.await.unwrap();
-            assert_eq!(summary.get_point_count(), MESSAGE_NUM);
-        }
-
-        // Test for send all and all buffer hints are true
-        {
-            let (mut sink, receiver) = client.record_route().unwrap();
-            let mut send_data = vec![];
-            for i in 0..MESSAGE_NUM {
-                let mut p = Point::default();
-                p.set_longitude(i);
-                send_data.push(p);
-            }
-            let send_stream = futures::stream::iter(send_data);
-            sink.enhance_batch(false);
-            sink.send_all(
-                &mut send_stream
-                    .map(move |item| Ok((item, WriteFlags::default().buffer_hint(true)))),
-            )
+        let send_stream = futures::stream::iter(send_data);
+        sink.send_all(&mut send_stream.map(move |item| Ok((item, WriteFlags::default()))))
             .await
             .unwrap();
-            // The following code is to test that when all msgs are set to be buffered, the msgs
-            // should be stored in the buffer until `sink.close()` is called.
-            let (mut tx, mut rx) = mpsc::channel(1);
-            let close_sink_task = async move {
-                rx.try_next().unwrap().unwrap();
-                Delay::new(std::time::Duration::from_secs(1)).await;
-                rx.try_next().unwrap_err();
-                sink.close().await.unwrap();
-                Delay::new(std::time::Duration::from_secs(1)).await;
-                rx.try_next().unwrap();
-            };
-            let recv_msg_task = async move {
-                tx.send(()).await.unwrap();
-                let summary = receiver.await.unwrap();
-                tx.send(()).await.unwrap();
-                assert_eq!(summary.get_point_count(), MESSAGE_NUM);
-            };
-            join!(recv_msg_task, close_sink_task);
+        let summary = receiver.await.unwrap();
+        assert_eq!(summary.get_point_count(), MESSAGE_NUM);
+
+        // Test for send all enable batch
+        let (mut sink, receiver) = client.record_route().unwrap();
+        let mut send_data = vec![];
+        for i in 0..MESSAGE_NUM {
+            let mut p = Point::default();
+            p.set_longitude(i);
+            send_data.push(p);
         }
+        let send_stream = futures::stream::iter(send_data);
+        sink.enhance_batch(true);
+        sink.send_all(&mut send_stream.map(move |item| Ok((item, WriteFlags::default()))))
+            .await
+            .unwrap();
+        let summary = receiver.await.unwrap();
+        assert_eq!(summary.get_point_count(), MESSAGE_NUM);
+
+        // Test for send all and all buffer hints are true
+        let (mut sink, receiver) = client.record_route().unwrap();
+        let mut send_data = vec![];
+        for i in 0..MESSAGE_NUM {
+            let mut p = Point::default();
+            p.set_longitude(i);
+            send_data.push(p);
+        }
+        let send_stream = futures::stream::iter(send_data);
+        sink.enhance_batch(false);
+        sink.send_all(
+            &mut send_stream.map(move |item| Ok((item, WriteFlags::default().buffer_hint(true)))),
+        )
+        .await
+        .unwrap();
+        // The following code is to test that when all msgs are set to be buffered, the msgs
+        // should be stored in the buffer until `sink.close()` is called.
+        let (mut tx, mut rx) = mpsc::channel(1);
+        let close_sink_task = async move {
+            Delay::new(std::time::Duration::from_secs(1)).await;
+            rx.try_next().unwrap_err();
+            sink.close().await.unwrap();
+            Delay::new(std::time::Duration::from_secs(1)).await;
+            rx.try_next().unwrap();
+        };
+        let recv_msg_task = async move {
+            let summary = receiver.await.unwrap();
+            tx.send(()).await.unwrap();
+            assert_eq!(summary.get_point_count(), MESSAGE_NUM);
+        };
+        join!(recv_msg_task, close_sink_task);
     };
     block_on(exec_test_f);
 }


### PR DESCRIPTION
close #415 

Optimize `send_all` using sink in grpc-rs. By buffering the message to be sent to determine whether there is still message in the stream, and add the `buffer_hint` flag to indicate follow-up messages.

After a simple test, this does improve the QPS by 50% when you use `send_all` method.

```
Before
======== test_client_stream_send_split
QPS: 13626.411713542033
======== test_client_stream_send_all
QPS: 13458.8795676736
======== test_server_stream_send_all
QPS: 21513.004479575207

After
======== test_client_stream_send_split
QPS: 13632.78241828707
======== test_client_stream_send_all
QPS: 20634.743684214573
======== test_server_stream_send_all
QPS: 21282.527286920154

Tcpdump capture file size (only send_all test)
Before：22M
After：2.6M
```

Related test code: https://github.com/hunterlxt/grpc-rs/blob/xt/bench-sink-over-master/tests-and-examples/examples/hello_world/client.rs

Additional benchmark with standard grpc driver (before vs after)
```
rust_protobuf_async_streaming_from_client_100msg_unconstrained
QPS: 12058.0
QPS: 41914.1
rust_protobuf_async_streaming_ping_pong
QPS: 18315.0
QPS: 20409.9
rust_protobuf_async_streaming_qps_unconstrained
QPS: 589875.8
QPS: 584359.6
```