### PR TITLE
Add blocking callback to EnvBuilder

### DIFF
--- a/src/env.rs
+++ b/src/env.rs
@@ -76,7 +76,7 @@ impl EnvBuilder {
     }
 
     /// Finalize the [`EnvBuilder`], build the [`Environment`] and initialize the gRPC library.
-    pub fn build(mut self) -> Environment {
+    pub fn build(self) -> Environment {
         unsafe {
             grpc_sys::grpc_init();
         }

--- a/tests-and-examples/tests/cases/misc.rs
+++ b/tests-and-examples/tests/cases/misc.rs
@@ -27,7 +27,16 @@ impl Greeter for PeerService {
 
 #[test]
 fn test_peer() {
-    let env = Arc::new(EnvBuilder::new().build());
+    let c1 = Arc::new(AtomicI32::new(0));
+    let c2 = c1.clone();
+    let env = Arc::new(
+        EnvBuilder::new()
+            .cq_count(2)
+            .after_start(move || {
+                c1.fetch_add(1, Ordering::Relaxed);
+            })
+            .build(),
+    );
     let service = create_greeter(PeerService);
     let mut server = ServerBuilder::new(env.clone())
         .register_service(service)
@@ -43,6 +52,7 @@ fn test_peer() {
     let resp = client.say_hello(&req).unwrap();
 
     assert!(resp.get_message().contains("127.0.0.1"), "{:?}", resp);
+    assert_eq!(c2.load(Ordering::Relaxed), 2);
 }
 
 #[derive(Clone)]

--- a/tests-and-examples/tests/cases/misc.rs
+++ b/tests-and-examples/tests/cases/misc.rs
@@ -27,13 +27,13 @@ impl Greeter for PeerService {
 
 #[test]
 fn test_peer() {
-    let c1 = Arc::new(AtomicI32::new(0));
-    let c2 = c1.clone();
+    let counter_add = Arc::new(AtomicI32::new(0));
+    let counter_collect = counter_add.clone();
     let env = Arc::new(
         EnvBuilder::new()
             .cq_count(2)
             .after_start(move || {
-                c1.fetch_add(1, Ordering::Relaxed);
+                counter_add.fetch_add(1, Ordering::Relaxed);
             })
             .build(),
     );
@@ -52,7 +52,7 @@ fn test_peer() {
     let resp = client.say_hello(&req).unwrap();
 
     assert!(resp.get_message().contains("127.0.0.1"), "{:?}", resp);
-    assert_eq!(c2.load(Ordering::Relaxed), 2);
+    assert_eq!(counter_collect.load(Ordering::Relaxed), 2);
 }
 
 #[derive(Clone)]


### PR DESCRIPTION
This allows users to manipulate the thread pool created by gRPC. They can add some custom code like print logs for newly created threads and reclaim some resources or record when exiting the thread.

Note: It is recommended to PR pick to 0.5.x

Signed-off-by: Xintao <hunterlxt@live.com>