### PR TITLE
compiler: do not emit rustfmt_skip inner attr, since it is unstable

### DIFF
--- a/compiler/src/codegen.rs
+++ b/compiler/src/codegen.rs
@@ -65,8 +65,6 @@ impl<'a> CodeWriter<'a> {
         self.write_line("#![allow(unknown_lints)]");
         self.write_line("#![allow(clippy::all)]");
         self.write_line("");
-        self.write_line("#![cfg_attr(rustfmt, rustfmt_skip)]");
-        self.write_line("");
         self.write_line("#![allow(box_pointers)]");
         self.write_line("#![allow(dead_code)]");
         self.write_line("#![allow(missing_docs)]");


### PR DESCRIPTION
Codegen emitted an inner `cfg_attr` attribute, which caused problems with stable Rust (according to https://github.com/tikv/raft-rs/issues/390#issuecomment-670342443). This PR removes that line. The user can always add it as an outer attribute if they want to skip formatting.

cc https://github.com/tikv/raft-rs/issues/390

PTAL @BusyJay @overvenus 
