### PR TITLE
*: use grpc_slice to avoid copy

### DIFF
--- a/benchmark/src/bench.rs
+++ b/benchmark/src/bench.rs
@@ -3,6 +3,7 @@
 #![allow(renamed_and_removed_lints)]
 
 use std::io::Read;
+use std::mem;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
@@ -16,6 +17,7 @@ use grpc::{
 use grpc_proto::testing::messages::{SimpleRequest, SimpleResponse};
 use grpc_proto::testing::services_grpc::BenchmarkService;
 use grpc_proto::util;
+use grpcio::GrpcSlice;
 
 fn gen_resp(req: &SimpleRequest) -> SimpleResponse {
     let payload = util::new_payload(req.get_response_size() as usize);
@@ -120,8 +122,11 @@ impl Generic {
 
 #[inline]
 #[allow(clippy::ptr_arg)]
-pub fn bin_ser(t: &Vec<u8>, buf: &mut Vec<u8>) {
-    buf.extend_from_slice(t)
+pub fn bin_ser(t: &Vec<u8>, buf: &mut GrpcSlice) {
+    unsafe {
+        let b: &mut [u8] = mem::transmute(buf.realloc(t.len()));
+        b.copy_from_slice(t);
+    }
 }
 
 #[inline]

--- a/benchmark/src/bench.rs
+++ b/benchmark/src/bench.rs
@@ -3,7 +3,6 @@
 #![allow(renamed_and_removed_lints)]
 
 use std::io::Read;
-use std::mem;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
@@ -124,7 +123,8 @@ impl Generic {
 #[allow(clippy::ptr_arg)]
 pub fn bin_ser(t: &Vec<u8>, buf: &mut GrpcSlice) {
     unsafe {
-        let b: &mut [u8] = mem::transmute(buf.realloc(t.len()));
+        let bytes = buf.realloc(t.len());
+        let b = &mut *(bytes as *mut [std::mem::MaybeUninit<u8>] as *mut [u8]);
         b.copy_from_slice(t);
     }
 }

--- a/grpc-sys/bindings/aarch64-unknown-linux-gnu-bindings.rs
+++ b/grpc-sys/bindings/aarch64-unknown-linux-gnu-bindings.rs
@@ -6844,8 +6844,7 @@ extern "C" {
     pub fn grpcwrap_call_start_unary(
         call: *mut grpc_call,
         ctx: *mut grpcwrap_batch_context,
-        send_buffer: *const ::std::os::raw::c_char,
-        send_buffer_len: usize,
+        send_buffer: *mut grpc_slice,
         write_flags: u32,
         initial_metadata: *mut grpc_metadata_array,
         initial_metadata_flags: u32,
@@ -6865,8 +6864,7 @@ extern "C" {
     pub fn grpcwrap_call_start_server_streaming(
         call: *mut grpc_call,
         ctx: *mut grpcwrap_batch_context,
-        send_buffer: *const ::std::os::raw::c_char,
-        send_buffer_len: usize,
+        send_buffer: *mut grpc_slice,
         write_flags: u32,
         initial_metadata: *mut grpc_metadata_array,
         initial_metadata_flags: u32,
@@ -6893,8 +6891,7 @@ extern "C" {
     pub fn grpcwrap_call_send_message(
         call: *mut grpc_call,
         ctx: *mut grpcwrap_batch_context,
-        send_buffer: *const ::std::os::raw::c_char,
-        send_buffer_len: usize,
+        send_buffer: *mut grpc_slice,
         write_flags: u32,
         send_empty_initial_metadata: i32,
         tag: *mut ::std::os::raw::c_void,
@@ -6915,8 +6912,7 @@ extern "C" {
         status_details_len: usize,
         trailing_metadata: *mut grpc_metadata_array,
         send_empty_initial_metadata: i32,
-        optional_send_buffer: *const ::std::os::raw::c_char,
-        optional_send_buffer_len: usize,
+        optional_send_buffer: *mut grpc_slice,
         write_flags: u32,
         tag: *mut ::std::os::raw::c_void,
     ) -> grpc_call_error;

--- a/grpc-sys/bindings/x86_64-unknown-linux-gnu-bindings.rs
+++ b/grpc-sys/bindings/x86_64-unknown-linux-gnu-bindings.rs
@@ -6844,8 +6844,7 @@ extern "C" {
     pub fn grpcwrap_call_start_unary(
         call: *mut grpc_call,
         ctx: *mut grpcwrap_batch_context,
-        send_buffer: *const ::std::os::raw::c_char,
-        send_buffer_len: usize,
+        send_buffer: *mut grpc_slice,
         write_flags: u32,
         initial_metadata: *mut grpc_metadata_array,
         initial_metadata_flags: u32,
@@ -6865,8 +6864,7 @@ extern "C" {
     pub fn grpcwrap_call_start_server_streaming(
         call: *mut grpc_call,
         ctx: *mut grpcwrap_batch_context,
-        send_buffer: *const ::std::os::raw::c_char,
-        send_buffer_len: usize,
+        send_buffer: *mut grpc_slice,
         write_flags: u32,
         initial_metadata: *mut grpc_metadata_array,
         initial_metadata_flags: u32,
@@ -6893,8 +6891,7 @@ extern "C" {
     pub fn grpcwrap_call_send_message(
         call: *mut grpc_call,
         ctx: *mut grpcwrap_batch_context,
-        send_buffer: *const ::std::os::raw::c_char,
-        send_buffer_len: usize,
+        send_buffer: *mut grpc_slice,
         write_flags: u32,
         send_empty_initial_metadata: i32,
         tag: *mut ::std::os::raw::c_void,
@@ -6915,8 +6912,7 @@ extern "C" {
         status_details_len: usize,
         trailing_metadata: *mut grpc_metadata_array,
         send_empty_initial_metadata: i32,
-        optional_send_buffer: *const ::std::os::raw::c_char,
-        optional_send_buffer_len: usize,
+        optional_send_buffer: *mut grpc_slice,
         write_flags: u32,
         tag: *mut ::std::os::raw::c_void,
     ) -> grpc_call_error;

--- a/grpc-sys/grpc_wrap.cc
+++ b/grpc-sys/grpc_wrap.cc
@@ -468,10 +468,9 @@ grpcwrap_channel_args_destroy(grpc_channel_args* args) {
 /* Call */
 
 GPR_EXPORT grpc_call_error GPR_CALLTYPE grpcwrap_call_start_unary(
-    grpc_call* call, grpcwrap_batch_context* ctx, const char* send_buffer,
-    size_t send_buffer_len, uint32_t write_flags,
-    grpc_metadata_array* initial_metadata, uint32_t initial_metadata_flags,
-    void* tag) {
+    grpc_call* call, grpcwrap_batch_context* ctx, grpc_slice* send_buffer,
+    uint32_t write_flags, grpc_metadata_array* initial_metadata,
+    uint32_t initial_metadata_flags, void* tag) {
   /* TODO: don't use magic number */
   grpc_op ops[6];
   memset(ops, 0, sizeof(ops));
@@ -484,7 +483,7 @@ GPR_EXPORT grpc_call_error GPR_CALLTYPE grpcwrap_call_start_unary(
   ops[0].reserved = nullptr;
 
   ops[1].op = GRPC_OP_SEND_MESSAGE;
-  ctx->send_message = string_to_byte_buffer(send_buffer, send_buffer_len);
+  ctx->send_message = grpc_raw_byte_buffer_create(send_buffer, 1);
   ops[1].data.send_message.send_message = ctx->send_message;
   ops[1].flags = write_flags;
   ops[1].reserved = nullptr;
@@ -559,10 +558,9 @@ GPR_EXPORT grpc_call_error GPR_CALLTYPE grpcwrap_call_start_client_streaming(
 }
 
 GPR_EXPORT grpc_call_error GPR_CALLTYPE grpcwrap_call_start_server_streaming(
-    grpc_call* call, grpcwrap_batch_context* ctx, const char* send_buffer,
-    size_t send_buffer_len, uint32_t write_flags,
-    grpc_metadata_array* initial_metadata, uint32_t initial_metadata_flags,
-    void* tag) {
+    grpc_call* call, grpcwrap_batch_context* ctx, grpc_slice* send_buffer,
+    uint32_t write_flags, grpc_metadata_array* initial_metadata,
+    uint32_t initial_metadata_flags, void* tag) {
   /* TODO: don't use magic number */
   grpc_op ops[4];
   memset(ops, 0, sizeof(ops));
@@ -575,7 +573,7 @@ GPR_EXPORT grpc_call_error GPR_CALLTYPE grpcwrap_call_start_server_streaming(
   ops[0].reserved = nullptr;
 
   ops[1].op = GRPC_OP_SEND_MESSAGE;
-  ctx->send_message = string_to_byte_buffer(send_buffer, send_buffer_len);
+  ctx->send_message = grpc_raw_byte_buffer_create(send_buffer, 1);
   ops[1].data.send_message.send_message = ctx->send_message;
   ops[1].flags = write_flags;
   ops[1].reserved = nullptr;
@@ -642,15 +640,14 @@ GPR_EXPORT grpc_call_error GPR_CALLTYPE grpcwrap_call_recv_initial_metadata(
 }
 
 GPR_EXPORT grpc_call_error GPR_CALLTYPE grpcwrap_call_send_message(
-    grpc_call* call, grpcwrap_batch_context* ctx, const char* send_buffer,
-    size_t send_buffer_len, uint32_t write_flags,
-    int32_t send_empty_initial_metadata, void* tag) {
+    grpc_call* call, grpcwrap_batch_context* ctx, grpc_slice* send_buffer,
+    uint32_t write_flags, int32_t send_empty_initial_metadata, void* tag) {
   /* TODO: don't use magic number */
   grpc_op ops[2];
   memset(ops, 0, sizeof(ops));
   size_t nops = send_empty_initial_metadata ? 2 : 1;
   ops[0].op = GRPC_OP_SEND_MESSAGE;
-  ctx->send_message = string_to_byte_buffer(send_buffer, send_buffer_len);
+  ctx->send_message = grpc_raw_byte_buffer_create(send_buffer, 1);
   ops[0].data.send_message.send_message = ctx->send_message;
   ops[0].flags = write_flags;
   ops[0].reserved = nullptr;
@@ -677,8 +674,7 @@ GPR_EXPORT grpc_call_error GPR_CALLTYPE grpcwrap_call_send_status_from_server(
     grpc_call* call, grpcwrap_batch_context* ctx, grpc_status_code status_code,
     const char* status_details, size_t status_details_len,
     grpc_metadata_array* trailing_metadata, int32_t send_empty_initial_metadata,
-    const char* optional_send_buffer, size_t optional_send_buffer_len,
-    uint32_t write_flags, void* tag) {
+    grpc_slice* optional_send_buffer, uint32_t write_flags, void* tag) {
   /* TODO: don't use magic number */
   grpc_op ops[3];
   memset(ops, 0, sizeof(ops));
@@ -698,8 +694,7 @@ GPR_EXPORT grpc_call_error GPR_CALLTYPE grpcwrap_call_send_status_from_server(
   ops[0].reserved = nullptr;
   if (optional_send_buffer) {
     ops[nops].op = GRPC_OP_SEND_MESSAGE;
-    ctx->send_message =
-        string_to_byte_buffer(optional_send_buffer, optional_send_buffer_len);
+    ctx->send_message = grpc_raw_byte_buffer_create(optional_send_buffer, 1);
     ops[nops].data.send_message.send_message = ctx->send_message;
     ops[nops].flags = write_flags;
     ops[nops].reserved = nullptr;

--- a/src/buf.rs
+++ b/src/buf.rs
@@ -62,6 +62,11 @@ impl GrpcSlice {
         GrpcSlice::from_static_slice(s.as_bytes())
     }
 
+    /// Checks whether the slice stores bytes inline.
+    pub fn is_inline(&self) -> bool {
+        self.0.refcount.is_null()
+    }
+
     /// Reallocates current slice with given capacity.
     ///
     /// The length of returned slice is the exact same as given cap.

--- a/src/buf.rs
+++ b/src/buf.rs
@@ -7,6 +7,8 @@ use std::fmt::{self, Debug, Formatter};
 use std::io::{self, BufRead, Read};
 use std::mem::{self, ManuallyDrop, MaybeUninit};
 
+/// Copied from grpc-sys/grpc/include/grpc/impl/codegen/slice.h. Unfortunately bindgen doesn't
+/// generate it automatically.
 const INLINED_SIZE: usize = mem::size_of::<libc::size_t>() + mem::size_of::<*mut u8>() - 1
     + mem::size_of::<*mut libc::c_void>();
 

--- a/src/call/client.rs
+++ b/src/call/client.rs
@@ -14,6 +14,7 @@ use parking_lot::Mutex;
 use std::future::Future;
 
 use super::{ShareCall, ShareCallHolder, SinkBase, WriteFlags};
+use crate::buf::GrpcSlice;
 use crate::call::{check_run, Call, MessageReader, Method};
 use crate::channel::Channel;
 use crate::codec::{DeserializeFn, SerializeFn};
@@ -108,14 +109,13 @@ impl Call {
         mut opt: CallOption,
     ) -> Result<ClientUnaryReceiver<Resp>> {
         let call = channel.create_call(method, &opt)?;
-        let mut payload = vec![];
+        let mut payload = GrpcSlice::default();
         (method.req_ser())(req, &mut payload);
         let cq_f = check_run(BatchType::CheckRead, |ctx, tag| unsafe {
             grpc_sys::grpcwrap_call_start_unary(
                 call.call,
                 ctx,
-                payload.as_ptr() as *const _,
-                payload.len(),
+                &mut payload,
                 opt.write_flags.flags,
                 opt.headers
                     .as_mut()
@@ -162,14 +162,13 @@ impl Call {
         mut opt: CallOption,
     ) -> Result<ClientSStreamReceiver<Resp>> {
         let call = channel.create_call(method, &opt)?;
-        let mut payload = vec![];
+        let mut payload = GrpcSlice::default();
         (method.req_ser())(req, &mut payload);
         let cq_f = check_run(BatchType::Finish, |ctx, tag| unsafe {
             grpc_sys::grpcwrap_call_start_server_streaming(
                 call.call,
                 ctx,
-                payload.as_ptr() as _,
-                payload.len(),
+                &mut payload,
                 opt.write_flags.flags,
                 opt.headers
                     .as_mut()

--- a/src/call/client.rs
+++ b/src/call/client.rs
@@ -115,7 +115,7 @@ impl Call {
             grpc_sys::grpcwrap_call_start_unary(
                 call.call,
                 ctx,
-                &mut payload,
+                payload.as_mut_ptr(),
                 opt.write_flags.flags,
                 opt.headers
                     .as_mut()
@@ -168,7 +168,7 @@ impl Call {
             grpc_sys::grpcwrap_call_start_server_streaming(
                 call.call,
                 ctx,
-                &mut payload,
+                payload.as_mut_ptr(),
                 opt.write_flags.flags,
                 opt.headers
                     .as_mut()

--- a/src/call/mod.rs
+++ b/src/call/mod.rs
@@ -731,7 +731,9 @@ impl SinkBase {
                 .start_send_message(&mut self.buffer, flags.flags, self.send_metadata)
         })?;
         self.batch_f = Some(write_f);
-        self.buffer = GrpcSlice::default();
+        if !self.buffer.is_inline() {
+            self.buffer = GrpcSlice::default();
+        }
         self.buf_flags.take();
         Ok(())
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,6 +43,7 @@ mod security;
 mod server;
 mod task;
 
+pub use crate::buf::GrpcSlice;
 pub use crate::call::client::{
     CallOption, ClientCStreamReceiver, ClientCStreamSender, ClientDuplexReceiver,
     ClientDuplexSender, ClientSStreamReceiver, ClientUnaryReceiver, StreamingCallSink,

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -186,11 +186,27 @@ impl Metadata {
         }
     }
 
+    /// Decomposes a Metadata array into its raw components.
+    ///
+    /// Returns the raw pointer to the underlying data, the length of the vector (in elements),
+    /// and the allocated capacity of the data (in elements). These are the same arguments in
+    /// the same order as the arguments to from_raw_parts.
+    ///
+    /// After calling this function, the caller is responsible for the memory previously managed
+    /// by the Metadata. The only way to do this is to convert the raw pointer, length, and
+    /// capacity back into a Metadata with the from_raw_parts function, allowing the destructor
+    /// to perform the cleanup.
     pub fn into_raw_parts(self) -> (*mut grpc_metadata, usize, usize) {
         let s = ManuallyDrop::new(self);
         (s.0.metadata, s.0.count, s.0.capacity)
     }
 
+    /// Creates a Metadata directly from the raw components of another vector.
+    ///
+    /// ## Safety
+    ///
+    /// The operation is safe only if the three arguments are returned from `into_raw_parts`
+    /// and only convert once.
     pub unsafe fn from_raw_parts(p: *mut grpc_metadata, len: usize, cap: usize) -> Metadata {
         Metadata(grpc_metadata_array {
             count: len,


### PR DESCRIPTION
Use grpc_slice to reduce memory copy. If the messages are small,
this should reduce allocations.
