### PR TITLE
Update parking_lot to version 0.11

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ protobuf = { version = "2.0", optional = true }
 prost = { version = "0.6", optional = true }
 bytes = { version = "0.5", optional = true }
 log = "0.4"
-parking_lot = "0.10"
+parking_lot = "0.11"
 
 [workspace]
 members = ["proto", "benchmark", "compiler", "interop", "tests-and-examples"]


### PR DESCRIPTION
Thanks for maintaining this crate. Some additional context for this change:

We're considering grpc-rs for use in the Android open source project[1]. For Android, it's important that we limit the number of crate versions that are used because that reduces both memory and disk usage, both of critical importance on resource-constrained Android devices. Generally we try to achieve that by only depending on the latest version of each crate that we directly or indirectly use. This change moves us to the most recent version of parking_lot, which also results in updating to the most recent version of a couple of its dependencies.

[1]: https://android-review.googlesource.com/c/platform/external/rust/crates/grpcio/+/1460423