### PR TITLE
codec: check serialization result length

### DIFF
--- a/benchmark/src/bench.rs
+++ b/benchmark/src/bench.rs
@@ -100,8 +100,9 @@ impl Generic {
 
 #[inline]
 #[allow(clippy::ptr_arg)]
-pub fn bin_ser(t: &Vec<u8>, buf: &mut Vec<u8>) {
-    buf.extend_from_slice(t)
+pub fn bin_ser(t: &Vec<u8>, buf: &mut Vec<u8>) -> grpc::Result<()> {
+    buf.extend_from_slice(t);
+    Ok(())
 }
 
 #[inline]

--- a/src/call/client.rs
+++ b/src/call/client.rs
@@ -103,7 +103,7 @@ impl Call {
     ) -> Result<ClientUnaryReceiver<Resp>> {
         let call = channel.create_call(method, &opt)?;
         let mut payload = vec![];
-        (method.req_ser())(req, &mut payload);
+        (method.req_ser())(req, &mut payload)?;
         let cq_f = check_run(BatchType::CheckRead, |ctx, tag| unsafe {
             grpc_sys::grpcwrap_call_start_unary(
                 call.call,
@@ -157,7 +157,7 @@ impl Call {
     ) -> Result<ClientSStreamReceiver<Resp>> {
         let call = channel.create_call(method, &opt)?;
         let mut payload = vec![];
-        (method.req_ser())(req, &mut payload);
+        (method.req_ser())(req, &mut payload)?;
         let cq_f = check_run(BatchType::Finish, |ctx, tag| unsafe {
             grpc_sys::grpcwrap_call_start_server_streaming(
                 call.call,

--- a/src/call/mod.rs
+++ b/src/call/mod.rs
@@ -657,7 +657,7 @@ impl SinkBase {
         }
 
         self.buf.clear();
-        ser(t, &mut self.buf);
+        ser(t, &mut self.buf)?;
         if flags.get_buffer_hint() && self.send_metadata {
             // temporary fix: buffer hint with send meta will not send out any metadata.
             flags = flags.buffer_hint(false);

--- a/src/error.rs
+++ b/src/error.rs
@@ -5,8 +5,6 @@ use std::{error, fmt, result};
 use crate::call::RpcStatus;
 use crate::grpc_sys::grpc_call_error;
 
-#[cfg(feature = "prost-codec")]
-use prost::DecodeError;
 #[cfg(feature = "protobuf-codec")]
 use protobuf::ProtobufError;
 
@@ -64,8 +62,15 @@ impl From<ProtobufError> for Error {
 }
 
 #[cfg(feature = "prost-codec")]
-impl From<DecodeError> for Error {
-    fn from(e: DecodeError) -> Error {
+impl From<prost::DecodeError> for Error {
+    fn from(e: prost::DecodeError) -> Error {
+        Error::Codec(Box::new(e))
+    }
+}
+
+#[cfg(feature = "prost-codec")]
+impl From<prost::EncodeError> for Error {
+    fn from(e: prost::EncodeError) -> Error {
         Error::Codec(Box::new(e))
     }
 }


### PR DESCRIPTION
grpc c core can only handle message that is not larger than 4GiB.

This is a cherry-pick of #495.