### PR TITLE
Allow CXX environment variable to override g++ for musl build

### DIFF
--- a/grpc-sys/build.rs
+++ b/grpc-sys/build.rs
@@ -75,7 +75,9 @@ fn build_grpc(cc: &mut cc::Build, library: &str) {
             println!("cargo:rustc-link-lib=framework=CoreFoundation");
         }
 
-        if env::var("CARGO_CFG_TARGET_ENV").unwrap() == "musl" {
+        if let Some(val) = get_env("CXX") {
+            config.define("CMAKE_CXX_COMPILER", val);
+        } else if env::var("CARGO_CFG_TARGET_ENV").unwrap() == "musl" {
             config.define("CMAKE_CXX_COMPILER", "g++");
         }
 


### PR DESCRIPTION
The `musl-gcc` cross compiler doesn't come with a corresponding
`musl-g++`, so #195 hard-coded the C++ compiler to `g++` when
building for musl. However, this results in building native binaries using
the native compiler, rather than an available musl toolchain (e.g.,
`x86_64-linux-musl-g++`).

This PR modifies the build script to allow the `CXX` environment
variable to override `g++`, even when building for musl.

cc: @csssuf @Hoverbear from #195