### PR TITLE
Add user-defined checker for server side

### DIFF
--- a/src/call/server.rs
+++ b/src/call/server.rs
@@ -25,7 +25,7 @@ use crate::codec::{DeserializeFn, SerializeFn};
 use crate::cq::CompletionQueue;
 use crate::error::{Error, Result};
 use crate::metadata::Metadata;
-use crate::server::Interceptor;
+use crate::server::CheckClosure;
 use crate::server::{BoxHandler, RequestCallContext};
 use crate::task::{BatchFuture, CallTag, Executor, Kicker};
 
@@ -75,13 +75,13 @@ impl RequestContext {
         cq: &CompletionQueue,
         rc: &mut RequestCallContext,
     ) -> result::Result<(), Self> {
-        let interceptor = rc.get_interceptor();
+        let checker = rc.get_checker();
         let handler = unsafe { rc.get_handler(self.method()) };
         match handler {
             Some(handler) => match handler.method_type() {
                 MethodType::Unary | MethodType::ServerStreaming => Err(self),
                 _ => {
-                    execute(self, cq, None, handler, interceptor);
+                    execute(self, cq, None, handler, checker);
                     Ok(())
                 }
             },
@@ -227,10 +227,10 @@ impl UnaryRequestContext {
         cq: &CompletionQueue,
         reader: Option<MessageReader>,
     ) {
-        let interceptor = rc.get_interceptor();
+        let checker = rc.get_checker();
         let handler = unsafe { rc.get_handler(self.request.method()).unwrap() };
         if reader.is_some() {
-            return execute(self.request, cq, reader, handler, interceptor);
+            return execute(self.request, cq, reader, handler, checker);
         }
 
         let status = RpcStatus::new(RpcStatusCode::INTERNAL, Some("No payload".to_owned()));
@@ -778,11 +778,11 @@ fn execute(
     cq: &CompletionQueue,
     payload: Option<MessageReader>,
     f: &mut BoxHandler,
-    interceptor: Option<Interceptor>,
+    checker: Option<CheckClosure>,
 ) {
     let rpc_ctx = RpcContext::new(ctx, cq);
 
-    if let Some(f) = interceptor {
+    if let Some(f) = checker {
         let should_execute = (f)(&rpc_ctx);
         if !should_execute {
             return;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,5 +78,5 @@ pub use crate::security::{
     ServerCredentialsBuilder, ServerCredentialsFetcher,
 };
 pub use crate::server::{
-    CheckResult, Server, ServerBuilder, Service, ServiceBuilder, ShutdownFuture,
+    CheckResult, Server, ServerBuilder, ServerChecker, Service, ServiceBuilder, ShutdownFuture,
 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,4 +77,6 @@ pub use crate::security::{
     CertificateRequestType, ChannelCredentials, ChannelCredentialsBuilder, ServerCredentials,
     ServerCredentialsBuilder, ServerCredentialsFetcher,
 };
-pub use crate::server::{Server, ServerBuilder, Service, ServiceBuilder, ShutdownFuture};
+pub use crate::server::{
+    CheckResult, Server, ServerBuilder, Service, ServiceBuilder, ShutdownFuture,
+};

--- a/src/server.rs
+++ b/src/server.rs
@@ -266,7 +266,7 @@ impl ServiceBuilder {
     }
 }
 
-pub(crate) type Interceptor = Arc<dyn Fn(&RpcContext) -> bool>;
+pub(crate) type Interceptor = Arc<dyn Fn(&RpcContext) -> bool + Send + Sync>;
 
 /// A gRPC service.
 ///
@@ -327,7 +327,10 @@ impl ServerBuilder {
     /// Add a custom interceptor to handle some tasks before the grpc call handler starts.
     ///
     /// WARNING: The closure must return `false` if the grpc call has ended in the interceptor.
-    pub fn add_interceptor<F: Fn(&RpcContext) -> bool + 'static>(mut self, f: F) -> ServerBuilder {
+    pub fn add_interceptor<F: Fn(&RpcContext) -> bool + 'static + Send + Sync>(
+        mut self,
+        f: F,
+    ) -> ServerBuilder {
         self.interceptor = Some(Arc::new(f));
         self
     }

--- a/src/server.rs
+++ b/src/server.rs
@@ -346,7 +346,7 @@ impl ServerBuilder {
     /// multiple checkers and they will be executed in the order added.
     ///
     /// TODO: Extend this interface to intercepte each payload like grpc-c++.
-    pub fn add_checker<C: ServerChecker + Send + 'static>(mut self, checker: C) -> ServerBuilder {
+    pub fn add_checker<C: ServerChecker + 'static>(mut self, checker: C) -> ServerBuilder {
         self.checkers.push(Box::new(checker));
         self
     }

--- a/src/server.rs
+++ b/src/server.rs
@@ -267,6 +267,8 @@ impl ServiceBuilder {
     }
 }
 
+/// Used to indicate the result of the check. If it returns `Abort`,
+/// skip the subsequent checkers and abort the grpc call.
 pub enum CheckResult {
     Continue,
     Abort(RpcStatus),
@@ -331,7 +333,7 @@ impl ServerBuilder {
     }
 
     /// Add a custom checker to handle some tasks before the grpc call handler starts.
-    /// This allows users to operate grpc call based on the context. The user can add
+    /// This allows users to operate grpc call based on the context. Users can add
     /// multiple checkers and they will be executed in the order added.
     ///
     /// TODO: Extend this interface to implement interceptor function like grpc-c++.

--- a/src/server.rs
+++ b/src/server.rs
@@ -274,7 +274,7 @@ pub enum CheckResult {
     Abort(RpcStatus),
 }
 
-pub(crate) type CheckClosure = Arc<dyn Fn(&RpcContext) -> CheckResult + Send + Sync>;
+pub(crate) type CheckClosure = Arc<dyn Fn(&RpcContext) -> CheckResult + Send>;
 
 /// A gRPC service.
 ///
@@ -337,7 +337,7 @@ impl ServerBuilder {
     /// multiple checkers and they will be executed in the order added.
     ///
     /// TODO: Extend this interface to implement interceptor function like grpc-c++.
-    pub fn add_checker<F: Fn(&RpcContext) -> CheckResult + 'static + Send + Sync>(
+    pub fn add_checker<F: Fn(&RpcContext) -> CheckResult + Send + 'static>(
         mut self,
         f: F,
     ) -> ServerBuilder {

--- a/tests-and-examples/tests/cases/misc.rs
+++ b/tests-and-examples/tests/cases/misc.rs
@@ -224,23 +224,14 @@ fn test_shutdown_when_exists_grpc_call() {
 
 #[test]
 fn test_custom_checker_server_side() {
-    let flag_1 = Arc::new(atomic::AtomicBool::new(false));
-    let flag_2 = flag_1.clone();
+    let flag = Arc::new(atomic::AtomicBool::new(false));
+    let checker = FlagChecker { flag: flag.clone() };
 
     let env = Arc::new(Environment::new(2));
     // Start a server and delay the process of grpc server.
     let service = create_greeter(PeerService);
     let mut server = ServerBuilder::new(env.clone())
-        .add_checker(move |ctx| {
-            let method = String::from_utf8(ctx.method().to_owned());
-            assert_eq!(&method.unwrap(), "/helloworld.Greeter/SayHello");
-
-            if flag_1.load(Ordering::SeqCst) {
-                CheckResult::Abort(RpcStatus::new(RpcStatusCode::DATA_LOSS, None))
-            } else {
-                CheckResult::Continue
-            }
-        })
+        .add_checker(checker)
         .register_service(service)
         .bind("127.0.0.1", 0)
         .build()
@@ -254,9 +245,31 @@ fn test_custom_checker_server_side() {
     let _ = client.say_hello(&req).unwrap();
     let _ = client.say_hello(&req).unwrap();
 
-    flag_2.store(true, Ordering::SeqCst);
+    flag.store(true, Ordering::SeqCst);
     assert_eq!(
         client.say_hello(&req).unwrap_err().to_string(),
         "RpcFailure: 15-DATA_LOSS ".to_owned()
     );
+}
+
+#[derive(Clone)]
+struct FlagChecker {
+    flag: Arc<atomic::AtomicBool>,
+}
+
+impl ServerChecker for FlagChecker {
+    fn check(&mut self, ctx: &RpcContext) -> CheckResult {
+        let method = String::from_utf8(ctx.method().to_owned());
+        assert_eq!(&method.unwrap(), "/helloworld.Greeter/SayHello");
+
+        if self.flag.load(Ordering::SeqCst) {
+            CheckResult::Abort(RpcStatus::new(RpcStatusCode::DATA_LOSS, None))
+        } else {
+            CheckResult::Continue
+        }
+    }
+
+    fn box_clone(&self) -> Box<dyn ServerChecker> {
+        Box::new(self.clone())
+    }
 }

--- a/tests-and-examples/tests/cases/misc.rs
+++ b/tests-and-examples/tests/cases/misc.rs
@@ -223,15 +223,15 @@ fn test_shutdown_when_exists_grpc_call() {
 }
 
 #[test]
-fn test_interceptor_for_server() {
+fn test_custom_checker_server_side() {
     let flag_1 = Arc::new(atomic::AtomicBool::new(false));
     let flag_2 = flag_1.clone();
 
     let env = Arc::new(Environment::new(2));
     // Start a server and delay the process of grpc server.
-    let service = create_greeter(SleepService(true));
+    let service = create_greeter(PeerService);
     let mut server = ServerBuilder::new(env.clone())
-        .add_interceptor(move |ctx| {
+        .add_checker(move |ctx| {
             if flag_1.load(Ordering::Relaxed) {
                 let call = ctx.call();
                 call.abort(&RpcStatus::new(RpcStatusCode::DATA_LOSS, None));

--- a/tests-and-examples/tests/cases/misc.rs
+++ b/tests-and-examples/tests/cases/misc.rs
@@ -235,7 +235,7 @@ fn test_custom_checker_server_side() {
             let method = String::from_utf8(ctx.method().to_owned());
             assert_eq!(&method.unwrap(), "/helloworld.Greeter/SayHello");
 
-            if flag_1.load(Ordering::Relaxed) {
+            if flag_1.load(Ordering::SeqCst) {
                 CheckResult::Abort(RpcStatus::new(RpcStatusCode::DATA_LOSS, None))
             } else {
                 CheckResult::Continue
@@ -254,7 +254,7 @@ fn test_custom_checker_server_side() {
     let _ = client.say_hello(&req).unwrap();
     let _ = client.say_hello(&req).unwrap();
 
-    flag_2.store(true, Ordering::Relaxed);
+    flag_2.store(true, Ordering::SeqCst);
     assert_eq!(
         client.say_hello(&req).unwrap_err().to_string(),
         "RpcFailure: 15-DATA_LOSS ".to_owned()

--- a/tests-and-examples/tests/cases/misc.rs
+++ b/tests-and-examples/tests/cases/misc.rs
@@ -232,12 +232,13 @@ fn test_custom_checker_server_side() {
     let service = create_greeter(PeerService);
     let mut server = ServerBuilder::new(env.clone())
         .add_checker(move |ctx| {
+            let method = String::from_utf8(ctx.method().to_owned());
+            assert_eq!(&method.unwrap(), "/helloworld.Greeter/SayHello");
+
             if flag_1.load(Ordering::Relaxed) {
-                let call = ctx.call();
-                call.abort(&RpcStatus::new(RpcStatusCode::DATA_LOSS, None));
-                false
+                CheckResult::Abort(RpcStatus::new(RpcStatusCode::DATA_LOSS, None))
             } else {
-                true
+                CheckResult::Continue
             }
         })
         .register_service(service)

--- a/tests-and-examples/tests/cases/misc.rs
+++ b/tests-and-examples/tests/cases/misc.rs
@@ -224,15 +224,15 @@ fn test_shutdown_when_exists_grpc_call() {
 
 #[test]
 fn test_interceptor_for_server() {
-    let counter_1 = Arc::new(atomic::AtomicBool::new(false));
-    let counter_2 = counter_1.clone();
+    let flag_1 = Arc::new(atomic::AtomicBool::new(false));
+    let flag_2 = flag_1.clone();
 
     let env = Arc::new(Environment::new(2));
     // Start a server and delay the process of grpc server.
     let service = create_greeter(SleepService(true));
     let mut server = ServerBuilder::new(env.clone())
         .add_interceptor(move |ctx| {
-            if counter_1.load(Ordering::Relaxed) {
+            if flag_1.load(Ordering::Relaxed) {
                 let call = ctx.call();
                 call.abort(&RpcStatus::new(RpcStatusCode::DATA_LOSS, None));
                 false
@@ -253,7 +253,7 @@ fn test_interceptor_for_server() {
     let _ = client.say_hello(&req).unwrap();
     let _ = client.say_hello(&req).unwrap();
 
-    counter_2.store(true, Ordering::Relaxed);
+    flag_2.store(true, Ordering::Relaxed);
     assert_eq!(
         client.say_hello(&req).unwrap_err().to_string(),
         "RpcFailure: 15-DATA_LOSS ".to_owned()


### PR DESCRIPTION
Users can provide custom checker to decide if the grpc call should be aborted in advance or be continued. For operations like check common name, a lot of redundant code can be avoided.

## How to implement?
Execute the custom closure provided by the user at the `execute` function from `src/call/server.rs`. If the user declares that the grpc call has been aborted, then skip the subsequent grpc handler.

Signed-off-by: Xintao <hunterlxt@live.com>