### PR TITLE
grpc-sys: detect failure early

### DIFF
--- a/grpc-sys/build.rs
+++ b/grpc-sys/build.rs
@@ -70,7 +70,7 @@ fn clean_up_stale_cache(cxx_compiler: String) {
     let cache_stale = f.lines().any(|l| {
         let l = l.unwrap();
         trim_start(&l, "CMAKE_CXX_COMPILER:").map_or(false, |s| {
-            let mut splits = s.splitn(2, "=");
+            let mut splits = s.splitn(2, '=');
             splits.next();
             splits.next().map_or(false, |p| p != cxx_compiler)
         })


### PR DESCRIPTION
grpc c core 1.35 requires gcc 4.9+. It usually makes users switch
compiler on failure. But cmake doesn't work well on compiler changes, so
this pr detects the changes early and remove stale cache so that it can
finish compilation.