### PR TITLE
*: support connectivity related APIs

### DIFF
--- a/src/call/server.rs
+++ b/src/call/server.rs
@@ -3,6 +3,7 @@
 use std::ffi::CStr;
 use std::pin::Pin;
 use std::sync::Arc;
+use std::time::Duration;
 use std::{result, slice};
 
 use crate::grpc_sys::{
@@ -30,8 +31,10 @@ use crate::server::{BoxHandler, RequestCallContext};
 use crate::task::{BatchFuture, CallTag, Executor, Kicker};
 use crate::CheckResult;
 
+/// A point in time.
+#[derive(Clone, Copy)]
 pub struct Deadline {
-    spec: gpr_timespec,
+    pub(crate) spec: gpr_timespec,
 }
 
 impl Deadline {
@@ -44,11 +47,26 @@ impl Deadline {
         }
     }
 
-    pub fn exceeded(&self) -> bool {
+    /// Checks if the deadline is exceeded.
+    pub fn exceeded(self) -> bool {
         unsafe {
             let now = grpc_sys::gpr_now(gpr_clock_type::GPR_CLOCK_REALTIME);
             grpc_sys::gpr_time_cmp(now, self.spec) >= 0
         }
+    }
+
+    pub(crate) fn spec(self) -> gpr_timespec {
+        self.spec
+    }
+}
+
+impl From<Duration> for Deadline {
+    /// Build a deadline from given duration.
+    ///
+    /// The deadline will be `now + duration`.
+    #[inline]
+    fn from(dur: Duration) -> Deadline {
+        Deadline::new(dur.into())
     }
 }
 
@@ -626,8 +644,8 @@ impl<'a> RpcContext<'a> {
         self.ctx.host()
     }
 
-    pub fn deadline(&self) -> &Deadline {
-        &self.deadline
+    pub fn deadline(&self) -> Deadline {
+        self.deadline
     }
 
     /// Get the initial metadata sent by client.

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -8,8 +8,9 @@ use std::sync::Arc;
 use std::time::Duration;
 use std::{cmp, i32, ptr};
 
-use crate::grpc_sys::{
-    self, gpr_timespec, grpc_arg_pointer_vtable, grpc_channel, grpc_channel_args,
+use crate::{
+    grpc_sys::{self, gpr_timespec, grpc_arg_pointer_vtable, grpc_channel, grpc_channel_args},
+    Deadline,
 };
 use libc::{self, c_char, c_int};
 
@@ -17,6 +18,7 @@ use crate::call::{Call, Method};
 use crate::cq::CompletionQueue;
 use crate::env::Environment;
 use crate::error::Result;
+use crate::task::CallTag;
 use crate::task::Kicker;
 use crate::CallOption;
 use crate::ResourceQuota;
@@ -589,10 +591,55 @@ impl Channel {
         }
     }
 
-    // If try_to_connect is true, the channel will try to establish a connection, potentially
-    // changing the state.
+    /// If try_to_connect is true, the channel will try to establish a connection, potentially
+    /// changing the state.
     pub fn check_connectivity_state(&self, try_to_connect: bool) -> ConnectivityState {
         self.inner.check_connectivity_state(try_to_connect)
+    }
+
+    /// Blocking wait for channel state change or deadline expiration.
+    ///
+    /// `check_connectivity_state` needs to called to get the current state.
+    pub async fn wait_for_state_change(
+        &self,
+        last_observed: ConnectivityState,
+        deadline: impl Into<Deadline>,
+    ) -> bool {
+        let (cq_f, prom) = CallTag::action_pair();
+        let prom_box = Box::new(prom);
+        let tag = Box::into_raw(prom_box);
+        let cq_ref = match self.cq.borrow() {
+            Ok(r) => r,
+            // It's already shutdown.
+            Err(_) => return false,
+        };
+
+        unsafe {
+            grpcio_sys::grpc_channel_watch_connectivity_state(
+                self.inner.channel,
+                last_observed,
+                deadline.into().spec(),
+                cq_ref.as_ptr(),
+                tag as *mut _,
+            )
+        }
+        cq_f.await.unwrap()
+    }
+
+    /// Wait for this channel to be connected.
+    pub async fn wait_for_connected(&self, deadline: impl Into<Deadline>) -> bool {
+        let deadline = deadline.into();
+        loop {
+            let state = self.check_connectivity_state(true);
+            match state {
+                ConnectivityState::GRPC_CHANNEL_READY => return true,
+                ConnectivityState::GRPC_CHANNEL_SHUTDOWN => return false,
+                _ => (),
+            }
+            if !self.wait_for_state_change(state, deadline).await {
+                return false;
+            }
+        }
     }
 
     /// Create a Kicker.

--- a/src/server.rs
+++ b/src/server.rs
@@ -11,6 +11,7 @@ use std::sync::Arc;
 
 use crate::grpc_sys::{self, grpc_call_error, grpc_server};
 use futures::future::Future;
+use futures::ready;
 use futures::task::{Context, Poll};
 
 use crate::call::server::*;
@@ -523,14 +524,18 @@ pub fn request_call(ctx: RequestCallContext, cq: &CompletionQueue) {
 
 /// A `Future` that will resolve when shutdown completes.
 pub struct ShutdownFuture {
-    cq_f: CqFuture<()>,
+    cq_f: CqFuture<bool>,
 }
 
 impl Future for ShutdownFuture {
     type Output = Result<()>;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {
-        Pin::new(&mut self.cq_f).poll(cx)
+        match ready!(Pin::new(&mut self.cq_f).poll(cx)) {
+            Ok(true) => Poll::Ready(Ok(())),
+            Ok(false) => Poll::Ready(Err(Error::ShutdownFailed)),
+            Err(e) => unreachable!("action future should never resolve to error: {}", e),
+        }
     }
 }
 
@@ -549,7 +554,7 @@ pub struct Server {
 impl Server {
     /// Shutdown the server asynchronously.
     pub fn shutdown(&mut self) -> ShutdownFuture {
-        let (cq_f, prom) = CallTag::shutdown_pair();
+        let (cq_f, prom) = CallTag::action_pair();
         let prom_box = Box::new(prom);
         let tag = Box::into_raw(prom_box);
         unsafe {

--- a/src/task/promise.rs
+++ b/src/task/promise.rs
@@ -104,24 +104,22 @@ impl Debug for Batch {
     }
 }
 
-/// A promise used to resolve async shutdown result.
-pub struct Shutdown {
-    inner: Arc<Inner<()>>,
+/// A promise used to resolve async action status.
+///
+/// The action can only succeed or fail without extra error hint.
+pub struct Action {
+    inner: Arc<Inner<bool>>,
 }
 
-impl Shutdown {
-    pub fn new(inner: Arc<Inner<()>>) -> Shutdown {
-        Shutdown { inner }
+impl Action {
+    pub fn new(inner: Arc<Inner<bool>>) -> Action {
+        Action { inner }
     }
 
     pub fn resolve(self, success: bool) {
         let task = {
             let mut guard = self.inner.lock();
-            if success {
-                guard.set_result(Ok(()))
-            } else {
-                guard.set_result(Err(Error::ShutdownFailed))
-            }
+            guard.set_result(Ok(success))
         };
         task.map(|t| t.wake());
     }

--- a/tests-and-examples/tests/cases/misc.rs
+++ b/tests-and-examples/tests/cases/misc.rs
@@ -273,3 +273,84 @@ impl ServerChecker for FlagChecker {
         Box::new(self.clone())
     }
 }
+
+/// Tests connectivity related API works as expected.
+#[test]
+fn test_connectivity() {
+    let env = Arc::new(Environment::new(2));
+    let service = create_greeter(PeerService);
+    let mut server = ServerBuilder::new(env.clone())
+        .register_service(service)
+        .bind("localhost", 0)
+        .build()
+        .unwrap();
+    server.start();
+    let port = server.bind_addrs().next().unwrap().1;
+    // Using localhost instead of 127.0.0.1 to force name resolving, so test can observe
+    // connecting state of channel.
+    let ch = ChannelBuilder::new(env.clone()).connect(&format!("localhost:{}", port));
+    assert!(block_on(ch.wait_for_connected(Duration::from_secs(3))));
+    assert_eq!(
+        ch.check_connectivity_state(false),
+        ConnectivityState::GRPC_CHANNEL_READY
+    );
+
+    // Shutdown server should make the connection transit to failure.
+    block_on(server.shutdown()).unwrap();
+    assert!(block_on(ch.wait_for_state_change(
+        ConnectivityState::GRPC_CHANNEL_READY,
+        Duration::from_secs(3)
+    )));
+    // Shutdown will send goaway, hence the state goes to idle.
+    assert_eq!(
+        ch.check_connectivity_state(false),
+        ConnectivityState::GRPC_CHANNEL_IDLE
+    );
+
+    // There is no pending rpc, so grpc will not retry connecting.
+    assert!(!block_on(ch.wait_for_state_change(
+        ConnectivityState::GRPC_CHANNEL_IDLE,
+        Duration::from_millis(100)
+    )));
+
+    // Ask it to reconnect explicitly.
+    ch.check_connectivity_state(true);
+    assert!(block_on(ch.wait_for_state_change(
+        ConnectivityState::GRPC_CHANNEL_IDLE,
+        Duration::from_secs(3)
+    )));
+    assert_eq!(
+        ch.check_connectivity_state(false),
+        ConnectivityState::GRPC_CHANNEL_CONNECTING
+    );
+
+    // It can't be ready since no server is running.
+    assert!(!block_on(ch.wait_for_connected(Duration::from_millis(100))));
+    assert!(block_on(ch.wait_for_state_change(
+        ConnectivityState::GRPC_CHANNEL_CONNECTING,
+        Duration::from_secs(3)
+    )));
+    assert_eq!(
+        ch.check_connectivity_state(false),
+        ConnectivityState::GRPC_CHANNEL_TRANSIENT_FAILURE
+    );
+
+    // After server is restarted, client should be able to reconnect successfully.
+    // A shutdown server should not be restarted again, using a different instance.
+    let service = create_greeter(PeerService);
+    let mut server = ServerBuilder::new(env.clone())
+        .register_service(service)
+        .bind("localhost", port)
+        .build()
+        .unwrap();
+    server.start();
+    assert!(block_on(ch.wait_for_connected(Duration::from_secs(3))));
+    assert_eq!(
+        ch.check_connectivity_state(false),
+        ConnectivityState::GRPC_CHANNEL_READY
+    );
+    let client = GreeterClient::new(ch);
+    let req = HelloRequest::default();
+    let resp = client.say_hello(&req).unwrap();
+    assert!(!resp.get_message().is_empty());
+}


### PR DESCRIPTION
This PR adds the missing documented API `wait_for_state_change` to
channel, and add a helper function to wait for connected easily.

See also https://github.com/grpc/grpc/blob/master/doc/connectivity-semantics-and-api.md.

Close #483.
