### PR TITLE
channel: fix send issue in state change API

### DIFF
--- a/src/call/mod.rs
+++ b/src/call/mod.rs
@@ -33,9 +33,9 @@ impl From<i32> for RpcStatusCode {
     }
 }
 
-impl Into<i32> for RpcStatusCode {
-    fn into(self) -> i32 {
-        self.0
+impl From<RpcStatusCode> for i32 {
+    fn from(code: RpcStatusCode) -> i32 {
+        code.0
     }
 }
 

--- a/tests-and-examples/tests/cases/misc.rs
+++ b/tests-and-examples/tests/cases/misc.rs
@@ -351,8 +351,11 @@ fn test_connectivity() {
         ch.check_connectivity_state(false),
         ConnectivityState::GRPC_CHANNEL_READY
     );
-    let client = GreeterClient::new(ch);
+    let client = GreeterClient::new(ch.clone());
     let req = HelloRequest::default();
     let resp = client.say_hello(&req).unwrap();
     assert!(!resp.get_message().is_empty());
+    client.spawn(async move {
+        ch.wait_for_connected(Duration::from_secs(3)).await;
+    });
 }


### PR DESCRIPTION
async/await doesn't work well with temporary variables, this PR changes
it to `impl Future` to get around Send requirement.
