### PR TITLE
Make boringssl-src optional

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,8 @@ on:
 
 env:
   RUST_BACKTRACE: 1
-  RUSTFLAGS: "--deny=warnings"
+  # Some of the bindgen tests generate "deref-nullptr" warnings, see https://github.com/rust-lang/rust-bindgen/issues/1651
+  RUSTFLAGS: "--deny=warnings --allow deref-nullptr"
   TEST_BIND: 1
 
 jobs:
@@ -100,6 +101,7 @@ jobs:
     runs-on: windows-latest
     env:
       LIBCLANG_PATH: 'C:\Program Files\LLVM\bin'
+      RUSTFLAGS: ""
     steps:
     - uses: actions/checkout@v2
     - run: choco install -y llvm

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,8 @@ env:
     # absl deadlock detection performs poorly on arm, so we build it release
     # mode to skip the check. Enabling debug-assertions to get safer test
     # results.
-    - RUSTFLAGS="--deny=warnings -C debug-assertions"
+    # Some of the bindgen tests generate "deref-nullptr" warnings, see https://github.com/rust-lang/rust-bindgen/issues/1651
+    - RUSTFLAGS="--deny=warnings -C debug-assertions --allow deref-nullptr"
     - TEST_BIND=1
 
 addons:

--- a/grpc-sys/Cargo.toml
+++ b/grpc-sys/Cargo.toml
@@ -54,7 +54,7 @@ libz-sys = { version = "1.1.3", default-features = false, features = ["libc", "s
 
 [features]
 default = ["use-bindgen"]
-secure = []
+secure = ["boringssl-src"]
 openssl = ["secure"]
 openssl-vendored = ["openssl", "openssl-sys"]
 no-omit-frame-pointer = []
@@ -70,4 +70,4 @@ pkg-config = "0.3"
 walkdir = "2.2.9"
 # Because of rust-lang/cargo#5237, bindgen should not be upgraded util a minor or major release.
 bindgen = { version = "0.57.0", default-features = false, optional = true, features = ["runtime"] }
-boringssl-src = "0.3.0"
+boringssl-src = { version = "0.3.0", optional = true }

--- a/grpc-sys/build.rs
+++ b/grpc-sys/build.rs
@@ -172,7 +172,11 @@ fn build_grpc(cc: &mut cc::Build, library: &str) {
         config.define("gRPC_BUILD_CODEGEN", "false");
         // We don't need to build benchmarks.
         config.define("gRPC_BENCHMARK_PROVIDER", "none");
-        config.define("gRPC_SSL_PROVIDER", "package");
+
+        if cfg!(feature = "secure") {
+            config.define("gRPC_SSL_PROVIDER", "package");
+        }
+        #[cfg(feature = "secure")]
         if cfg!(feature = "openssl") {
             if cfg!(feature = "openssl-vendored") {
                 config.register_dep("openssl");
@@ -254,6 +258,7 @@ fn figure_ssl_path(build_dir: &str) {
     println!("cargo:rustc-link-lib=crypto");
 }
 
+#[cfg(feature = "secure")]
 fn build_boringssl(config: &mut CmakeConfig) {
     let boringssl_artifact = boringssl_src::Build::new().build();
     config.define(

--- a/grpc-sys/build.rs
+++ b/grpc-sys/build.rs
@@ -173,6 +173,8 @@ fn build_grpc(cc: &mut cc::Build, library: &str) {
         // We don't need to build benchmarks.
         config.define("gRPC_BENCHMARK_PROVIDER", "none");
 
+        // `package` should only be set for secure feature, otherwise cmake will always search for
+        // ssl library.
         if cfg!(feature = "secure") {
             config.define("gRPC_SSL_PROVIDER", "package");
         }

--- a/health/src/proto/protobuf/health_grpc.rs
+++ b/health/src/proto/protobuf/health_grpc.rs
@@ -4,6 +4,7 @@
 // https://github.com/Manishearth/rust-clippy/issues/702
 #![allow(unknown_lints)]
 #![allow(clippy::all)]
+
 #![allow(box_pointers)]
 #![allow(dead_code)]
 #![allow(missing_docs)]
@@ -15,36 +16,18 @@
 #![allow(unused_imports)]
 #![allow(unused_results)]
 
-const METHOD_HEALTH_CHECK: ::grpcio::Method<
-    super::health::HealthCheckRequest,
-    super::health::HealthCheckResponse,
-> = ::grpcio::Method {
+const METHOD_HEALTH_CHECK: ::grpcio::Method<super::health::HealthCheckRequest, super::health::HealthCheckResponse> = ::grpcio::Method {
     ty: ::grpcio::MethodType::Unary,
     name: "/grpc.health.v1.Health/Check",
-    req_mar: ::grpcio::Marshaller {
-        ser: ::grpcio::pb_ser,
-        de: ::grpcio::pb_de,
-    },
-    resp_mar: ::grpcio::Marshaller {
-        ser: ::grpcio::pb_ser,
-        de: ::grpcio::pb_de,
-    },
+    req_mar: ::grpcio::Marshaller { ser: ::grpcio::pb_ser, de: ::grpcio::pb_de },
+    resp_mar: ::grpcio::Marshaller { ser: ::grpcio::pb_ser, de: ::grpcio::pb_de },
 };
 
-const METHOD_HEALTH_WATCH: ::grpcio::Method<
-    super::health::HealthCheckRequest,
-    super::health::HealthCheckResponse,
-> = ::grpcio::Method {
+const METHOD_HEALTH_WATCH: ::grpcio::Method<super::health::HealthCheckRequest, super::health::HealthCheckResponse> = ::grpcio::Method {
     ty: ::grpcio::MethodType::ServerStreaming,
     name: "/grpc.health.v1.Health/Watch",
-    req_mar: ::grpcio::Marshaller {
-        ser: ::grpcio::pb_ser,
-        de: ::grpcio::pb_de,
-    },
-    resp_mar: ::grpcio::Marshaller {
-        ser: ::grpcio::pb_ser,
-        de: ::grpcio::pb_de,
-    },
+    req_mar: ::grpcio::Marshaller { ser: ::grpcio::pb_ser, de: ::grpcio::pb_de },
+    resp_mar: ::grpcio::Marshaller { ser: ::grpcio::pb_ser, de: ::grpcio::pb_de },
 };
 
 #[derive(Clone)]
@@ -59,73 +42,39 @@ impl HealthClient {
         }
     }
 
-    pub fn check_opt(
-        &self,
-        req: &super::health::HealthCheckRequest,
-        opt: ::grpcio::CallOption,
-    ) -> ::grpcio::Result<super::health::HealthCheckResponse> {
+    pub fn check_opt(&self, req: &super::health::HealthCheckRequest, opt: ::grpcio::CallOption) -> ::grpcio::Result<super::health::HealthCheckResponse> {
         self.client.unary_call(&METHOD_HEALTH_CHECK, req, opt)
     }
 
-    pub fn check(
-        &self,
-        req: &super::health::HealthCheckRequest,
-    ) -> ::grpcio::Result<super::health::HealthCheckResponse> {
+    pub fn check(&self, req: &super::health::HealthCheckRequest) -> ::grpcio::Result<super::health::HealthCheckResponse> {
         self.check_opt(req, ::grpcio::CallOption::default())
     }
 
-    pub fn check_async_opt(
-        &self,
-        req: &super::health::HealthCheckRequest,
-        opt: ::grpcio::CallOption,
-    ) -> ::grpcio::Result<::grpcio::ClientUnaryReceiver<super::health::HealthCheckResponse>> {
+    pub fn check_async_opt(&self, req: &super::health::HealthCheckRequest, opt: ::grpcio::CallOption) -> ::grpcio::Result<::grpcio::ClientUnaryReceiver<super::health::HealthCheckResponse>> {
         self.client.unary_call_async(&METHOD_HEALTH_CHECK, req, opt)
     }
 
-    pub fn check_async(
-        &self,
-        req: &super::health::HealthCheckRequest,
-    ) -> ::grpcio::Result<::grpcio::ClientUnaryReceiver<super::health::HealthCheckResponse>> {
+    pub fn check_async(&self, req: &super::health::HealthCheckRequest) -> ::grpcio::Result<::grpcio::ClientUnaryReceiver<super::health::HealthCheckResponse>> {
         self.check_async_opt(req, ::grpcio::CallOption::default())
     }
 
-    pub fn watch_opt(
-        &self,
-        req: &super::health::HealthCheckRequest,
-        opt: ::grpcio::CallOption,
-    ) -> ::grpcio::Result<::grpcio::ClientSStreamReceiver<super::health::HealthCheckResponse>> {
+    pub fn watch_opt(&self, req: &super::health::HealthCheckRequest, opt: ::grpcio::CallOption) -> ::grpcio::Result<::grpcio::ClientSStreamReceiver<super::health::HealthCheckResponse>> {
         self.client.server_streaming(&METHOD_HEALTH_WATCH, req, opt)
     }
 
-    pub fn watch(
-        &self,
-        req: &super::health::HealthCheckRequest,
-    ) -> ::grpcio::Result<::grpcio::ClientSStreamReceiver<super::health::HealthCheckResponse>> {
+    pub fn watch(&self, req: &super::health::HealthCheckRequest) -> ::grpcio::Result<::grpcio::ClientSStreamReceiver<super::health::HealthCheckResponse>> {
         self.watch_opt(req, ::grpcio::CallOption::default())
     }
-    pub fn spawn<F>(&self, f: F)
-    where
-        F: ::futures::Future<Output = ()> + Send + 'static,
-    {
+    pub fn spawn<F>(&self, f: F) where F: ::futures::Future<Output = ()> + Send + 'static {
         self.client.spawn(f)
     }
 }
 
 pub trait Health {
-    fn check(
-        &mut self,
-        ctx: ::grpcio::RpcContext,
-        _req: super::health::HealthCheckRequest,
-        sink: ::grpcio::UnarySink<super::health::HealthCheckResponse>,
-    ) {
+    fn check(&mut self, ctx: ::grpcio::RpcContext, _req: super::health::HealthCheckRequest, sink: ::grpcio::UnarySink<super::health::HealthCheckResponse>) {
         grpcio::unimplemented_call!(ctx, sink)
     }
-    fn watch(
-        &mut self,
-        ctx: ::grpcio::RpcContext,
-        _req: super::health::HealthCheckRequest,
-        sink: ::grpcio::ServerStreamingSink<super::health::HealthCheckResponse>,
-    ) {
+    fn watch(&mut self, ctx: ::grpcio::RpcContext, _req: super::health::HealthCheckRequest, sink: ::grpcio::ServerStreamingSink<super::health::HealthCheckResponse>) {
         grpcio::unimplemented_call!(ctx, sink)
     }
 }

--- a/src/call/mod.rs
+++ b/src/call/mod.rs
@@ -781,7 +781,7 @@ impl SinkBase {
         // `start_send` is supposed to be called after `poll_ready` returns ready.
         assert!(self.batch_f.is_none());
 
-        let mut flags = self.buf_flags.clone().unwrap();
+        let mut flags = self.buf_flags.unwrap();
         flags = flags.buffer_hint(buffer_hint);
         let write_f = call.call(|c| {
             c.call

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -395,6 +395,7 @@ impl ChannelBuilder {
 
     /// Build `ChannelArgs` from the current configuration.
     #[allow(clippy::useless_conversion)]
+    #[allow(clippy::cmp_owned)]
     pub fn build_args(&self) -> ChannelArgs {
         let args = unsafe { grpc_sys::grpcwrap_channel_args_create(self.options.len()) };
         for (i, (k, v)) in self.options.iter().enumerate() {


### PR DESCRIPTION
If the secure feature is disabled, it's not needed to compile the boringssl-src crate.

This assume that the `secure` feature is using `boringssl-src` by default which I think is the current behaviour.

A bad aspect of this is that `boringssl-src` will be compiled even if `openssl` is chosen but I think that is currently the case anyway?

Fix #536 