### PR TITLE
grpcio-health don't need grpcio with secure enabled

### DIFF
--- a/health/Cargo.toml
+++ b/health/Cargo.toml
@@ -20,7 +20,7 @@ use-bindgen = ["grpcio/use-bindgen"]
 
 [dependencies]
 futures = "0.3"
-grpcio = { path = "..", features = ["secure"], version = "0.9.0", default-features = false }
+grpcio = { path = "..", version = "0.9.0", default-features = false }
 prost = { version = "0.7", optional = true }
 protobuf = { version = "2", optional = true }
 log = "0.4"


### PR DESCRIPTION
Using `grpcio-health` in project that don't need secure grpc will just slow down compilation.