### PR TITLE
Update prost to 0.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grpcio"
-version = "0.10.0"
+version = "0.9.0"
 edition = "2018"
 authors = ["The TiKV Project Developers"]
 license = "Apache-2.0"
@@ -53,4 +53,4 @@ use-bindgen = ["grpcio-sys/use-bindgen"]
 travis-ci = { repository = "tikv/grpc-rs" }
 
 [patch.crates-io]
-grpcio-compiler = { path = "compiler", version = "0.10.0", default-features = false }
+grpcio-compiler = { path = "compiler", version = "0.9.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grpcio"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2018"
 authors = ["The TiKV Project Developers"]
 license = "Apache-2.0"
@@ -21,7 +21,7 @@ grpcio-sys = { path = "grpc-sys", version = "0.9", default-features = false }
 libc = "0.2"
 futures = "0.3"
 protobuf = { version = "2.0", optional = true }
-prost = { version = "0.7", optional = true }
+prost = { version = "0.8", optional = true }
 bytes = { version = "1.0", optional = true }
 log = "0.4"
 parking_lot = "0.11"
@@ -53,4 +53,4 @@ use-bindgen = ["grpcio-sys/use-bindgen"]
 travis-ci = { repository = "tikv/grpc-rs" }
 
 [patch.crates-io]
-grpcio-compiler = { path = "compiler", version = "0.9.0", default-features = false }
+grpcio-compiler = { path = "compiler", version = "0.10.0", default-features = false }

--- a/compiler/Cargo.toml
+++ b/compiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grpcio-compiler"
-version = "0.10.0"
+version = "0.9.0"
 edition = "2018"
 authors = ["The TiKV Project Developers"]
 license = "Apache-2.0"

--- a/compiler/Cargo.toml
+++ b/compiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grpcio-compiler"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2018"
 authors = ["The TiKV Project Developers"]
 license = "Apache-2.0"
@@ -18,9 +18,9 @@ prost-codec = ["prost-build", "prost-types", "prost", "derive-new", "tempfile"]
 
 [dependencies]
 protobuf = { version = "2", optional = true }
-prost = { version = "0.7", optional = true }
-prost-build = { version = "0.7", optional = true }
-prost-types = { version = "0.7", optional = true }
+prost = { version = "0.8", optional = true }
+prost-build = { version = "0.8", optional = true }
+prost-types = { version = "0.8", optional = true }
 derive-new = { version = "0.5", optional = true }
 tempfile = { version = "3.0", optional = true }
 

--- a/health/Cargo.toml
+++ b/health/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grpcio-health"
-version = "0.10.0"
+version = "0.9.0"
 edition = "2018"
 authors = ["The TiKV Project Developers"]
 license = "Apache-2.0"
@@ -20,7 +20,7 @@ use-bindgen = ["grpcio/use-bindgen"]
 
 [dependencies]
 futures = "0.3"
-grpcio = { path = "..", features = ["secure"], version = "0.10.0", default-features = false }
+grpcio = { path = "..", features = ["secure"], version = "0.9.0", default-features = false }
 prost = { version = "0.8", optional = true }
 protobuf = { version = "2", optional = true }
 log = "0.4"

--- a/health/Cargo.toml
+++ b/health/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grpcio-health"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2018"
 authors = ["The TiKV Project Developers"]
 license = "Apache-2.0"
@@ -20,7 +20,7 @@ use-bindgen = ["grpcio/use-bindgen"]
 
 [dependencies]
 futures = "0.3"
-grpcio = { path = "..", features = ["secure"], version = "0.9.0", default-features = false }
-prost = { version = "0.7", optional = true }
+grpcio = { path = "..", features = ["secure"], version = "0.10.0", default-features = false }
+prost = { version = "0.8", optional = true }
 protobuf = { version = "2", optional = true }
 log = "0.4"

--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grpcio-proto"
-version = "0.10.0"
+version = "0.9.0"
 edition = "2018"
 authors = ["The TiKV Project Developers"]
 license = "Apache-2.0"
@@ -20,7 +20,7 @@ use-bindgen = ["grpcio/use-bindgen"]
 
 [dependencies]
 futures = "0.3"
-grpcio = { path = "..", features = ["secure"], version = "0.10.0", default-features = false }
+grpcio = { path = "..", features = ["secure"], version = "0.9.0", default-features = false }
 bytes = { version = "1.0", optional = true }
 prost = { version = "0.8", optional = true }
 prost-derive = { version = "0.8", optional = true }
@@ -29,5 +29,5 @@ protobuf = "2"
 lazy_static = { version = "1.3", optional = true }
 
 [build-dependencies]
-protobuf-build = { version = "0.12", default-features = false }
+protobuf-build = { version = ">=0.12", default-features = false }
 walkdir = "2.2"

--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grpcio-proto"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2018"
 authors = ["The TiKV Project Developers"]
 license = "Apache-2.0"
@@ -20,11 +20,11 @@ use-bindgen = ["grpcio/use-bindgen"]
 
 [dependencies]
 futures = "0.3"
-grpcio = { path = "..", features = ["secure"], version = "0.9.0", default-features = false }
+grpcio = { path = "..", features = ["secure"], version = "0.10.0", default-features = false }
 bytes = { version = "1.0", optional = true }
-prost = { version = "0.7", optional = true }
-prost-derive = { version = "0.7", optional = true }
-prost-types = { version = "0.7", optional = true }
+prost = { version = "0.8", optional = true }
+prost-derive = { version = "0.8", optional = true }
+prost-types = { version = "0.8", optional = true }
 protobuf = "2"
 lazy_static = { version = "1.3", optional = true }
 

--- a/tests-and-examples/Cargo.toml
+++ b/tests-and-examples/Cargo.toml
@@ -19,14 +19,14 @@ protobuf = { version = "2.22", optional = true }
 prost = { version = "0.8", optional = true }
 bytes = { version = "1.0", optional = true }
 log = "0.4"
-grpcio = { path = "..", version = "0.10", default-features = false, features = ["secure"] }
-grpcio-health = { path = "../health", version = "0.10", default-features = false }
+grpcio = { path = "..", version = "0.9", default-features = false, features = ["secure"] }
+grpcio-health = { path = "../health", version = "0.9", default-features = false }
 
 [dev-dependencies]
 serde_json = "1.0"
 serde = "1.0"
 serde_derive = "1.0"
-grpcio-proto = { path = "../proto", version = "0.10.0", default-features = false }
+grpcio-proto = { path = "../proto", version = "0.9.0", default-features = false }
 rand = "0.7"
 slog = "2.0"
 slog-async = "2.1"

--- a/tests-and-examples/Cargo.toml
+++ b/tests-and-examples/Cargo.toml
@@ -16,17 +16,17 @@ libc = "0.2"
 futures = "0.3"
 futures-timer = "3.0"
 protobuf = { version = "2.22", optional = true }
-prost = { version = "0.7", optional = true }
+prost = { version = "0.8", optional = true }
 bytes = { version = "1.0", optional = true }
 log = "0.4"
-grpcio = { path = "..", version = "0.9", default-features = false, features = ["secure"] }
-grpcio-health = { path = "../health", version = "0.9", default-features = false }
+grpcio = { path = "..", version = "0.10", default-features = false, features = ["secure"] }
+grpcio-health = { path = "../health", version = "0.10", default-features = false }
 
 [dev-dependencies]
 serde_json = "1.0"
 serde = "1.0"
 serde_derive = "1.0"
-grpcio-proto = { path = "../proto", version = "0.9.0", default-features = false }
+grpcio-proto = { path = "../proto", version = "0.10.0", default-features = false }
 rand = "0.7"
 slog = "2.0"
 slog-async = "2.1"

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-prost-build = "0.7"
+prost-build = "0.8"
 # Use an old enough version to make sure generated code with TiKV's fork.
 # TODO: use latest one when TiKV's fork is updated
 protoc-rust = "=2.8"


### PR DESCRIPTION
Update Prost to 0.8, to avoid security issue of 0.7 (RUSTSEC-2021-0073).
Related issue: tikv/tikv#10905, https://github.com/tikv/protobuf-build/pull/55

Note that `grpcio-proto` still depends on `prost 0.7` because of its build-dependency to `protobuf-build 0.12`. As `protobuf-build 0.12` depends on `grpcio-compiler 0.9`, there is a circular dependency between `grps-rs` and `protobuf-build`.

I think we should release `grps-rs` 0.10.0 first, then `protobuf-build` 0.13, and at last update `grpcio-proto` to depend on `protobuf-build` 0.13.

Signed-off-by: pingyu <shui.yu@126.com>