### PR TITLE
Reduce dependency on futures crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,8 @@ all-features = true
 [dependencies]
 grpcio-sys = { path = "grpc-sys", version = "0.9", default-features = false }
 libc = "0.2"
-futures = "0.3"
+futures-executor = "0.3"
+futures-util = { version = "0.3", default-features = false, features = ["std", "sink"] }
 protobuf = { version = "2.0", optional = true }
 prost = { version = "0.8", optional = true }
 bytes = { version = "1.0", optional = true }

--- a/benchmark/Cargo.toml
+++ b/benchmark/Cargo.toml
@@ -12,7 +12,9 @@ prost-codec = ["grpcio/prost-codec", "grpcio-proto/prost-codec"]
 [dependencies]
 grpcio = { path = ".." }
 grpcio-proto = { path = "../proto", default-features = false }
-futures = "0.3"
+futures-channel = "0.3"
+futures-executor = "0.3"
+futures-util = { version = "0.3", default-features = false, features = ["std", "sink"] }
 libc = "0.2"
 grpcio-sys = { path = "../grpc-sys" }
 rand = "0.7"

--- a/benchmark/src/bench.rs
+++ b/benchmark/src/bench.rs
@@ -6,8 +6,9 @@ use std::io::Read;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
-use futures::prelude::*;
-use futures::sink::SinkExt;
+use futures_util::{
+    FutureExt as _, SinkExt as _, StreamExt as _, TryFutureExt as _, TryStreamExt as _,
+};
 use grpc::{
     self, ClientStreamingSink, DuplexSink, MessageReader, Method, MethodType, RequestStream,
     RpcContext, ServiceBuilder, UnarySink, WriteFlags,

--- a/benchmark/src/client.rs
+++ b/benchmark/src/client.rs
@@ -1,14 +1,17 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
 use std::ffi::CString;
+use std::future::Future;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::{Duration, Instant};
 
-use futures::channel::oneshot::{self, Receiver, Sender};
-use futures::prelude::*;
-use futures::stream;
+use futures_channel::oneshot::{self, Receiver, Sender};
+use futures_util::stream;
+use futures_util::{
+    FutureExt as _, SinkExt as _, StreamExt as _, TryFutureExt as _, TryStreamExt as _,
+};
 use grpcio::{
     CallOption, Channel, ChannelBuilder, Client as GrpcClient, EnvBuilder, Environment, WriteFlags,
 };
@@ -442,6 +445,6 @@ impl Client {
     pub fn shutdown(&mut self) -> impl Future<Output = ()> + Send {
         self.keep_running.store(false, Ordering::Relaxed);
         let tasks = self.running_reqs.take().unwrap();
-        futures::future::join_all(tasks).map(|_| ())
+        futures_util::future::join_all(tasks).map(|_| ())
     }
 }

--- a/benchmark/src/main.rs
+++ b/benchmark/src/main.rs
@@ -1,21 +1,16 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
-extern crate benchmark;
-extern crate clap;
-extern crate futures;
 extern crate grpcio as grpc;
 extern crate grpcio_proto as grpc_proto;
 #[macro_use]
 extern crate log;
-extern crate rand;
 
 use std::env;
 use std::sync::Arc;
 
 use benchmark::{init_log, Worker};
 use clap::{App, Arg};
-use futures::channel::oneshot;
-use futures::executor::block_on;
+use futures_channel::oneshot;
 use grpc::{Environment, ServerBuilder};
 use grpc_proto::testing::services_grpc::create_worker_service;
 use rand::Rng;
@@ -55,6 +50,6 @@ fn main() {
 
     server.start();
 
-    let _ = block_on(rx);
-    let _ = block_on(server.shutdown());
+    let _ = futures_executor::block_on(rx);
+    let _ = futures_executor::block_on(server.shutdown());
 }

--- a/benchmark/src/worker.rs
+++ b/benchmark/src/worker.rs
@@ -2,8 +2,8 @@
 
 use std::sync::{Arc, Mutex};
 
-use futures::channel::oneshot::Sender;
-use futures::prelude::*;
+use futures_channel::oneshot::Sender;
+use futures_util::{FutureExt as _, SinkExt as _, TryFutureExt as _, TryStreamExt as _};
 use grpc_proto::testing::control::{
     ClientArgs, ClientStatus, CoreRequest, CoreResponse, ServerArgs, ServerStatus, Void,
 };

--- a/compiler/src/codegen.rs
+++ b/compiler/src/codegen.rs
@@ -592,7 +592,7 @@ impl<'a> ServiceGen<'a> {
                 method.write_client(w);
             }
             w.pub_fn(
-                "spawn<F>(&self, f: F) where F: ::futures::Future<Output = ()> + Send + 'static",
+                "spawn<F>(&self, f: F) where F: ::std::future::Future<Output = ()> + Send + 'static",
                 |w| {
                     w.write_line("self.client.spawn(f)");
                 },

--- a/compiler/src/prost_codegen.rs
+++ b/compiler/src/prost_codegen.rs
@@ -439,7 +439,7 @@ impl<'a> ClientMethod<'a> {
 fn generate_spawn(buf: &mut String) {
     buf.push_str(
         "pub fn spawn<F>(&self, f: F) \
-         where F: ::futures::Future<Output = ()> + Send + 'static {\
+         where F: ::std::future::Future<Output = ()> + Send + 'static {\
          self.client.spawn(f)\
          }\n",
     );

--- a/health/Cargo.toml
+++ b/health/Cargo.toml
@@ -19,7 +19,8 @@ prost-codec = ["grpcio/prost-codec", "prost"]
 use-bindgen = ["grpcio/use-bindgen"]
 
 [dependencies]
-futures = "0.3"
+futures-executor = "0.3"
+futures-util = { version = "0.3", default-features = false, features = ["std"] }
 grpcio = { path = "..", features = ["secure"], version = "0.9.0", default-features = false }
 prost = { version = "0.8", optional = true }
 protobuf = { version = "2", optional = true }

--- a/health/src/proto/prost/grpc.health.v1.rs
+++ b/health/src/proto/prost/grpc.health.v1.rs
@@ -32,7 +32,7 @@ pub fn check_async_opt(&self, req: &HealthCheckRequest, opt: ::grpcio::CallOptio
 pub fn check_async(&self, req: &HealthCheckRequest) -> ::grpcio::Result<::grpcio::ClientUnaryReceiver<HealthCheckResponse>,> { self.check_async_opt(req, ::grpcio::CallOption::default()) }
 pub fn watch_opt(&self, req: &HealthCheckRequest, opt: ::grpcio::CallOption) -> ::grpcio::Result<::grpcio::ClientSStreamReceiver<HealthCheckResponse>,> { self.client.server_streaming(&METHOD_HEALTH_WATCH, req, opt) }
 pub fn watch(&self, req: &HealthCheckRequest) -> ::grpcio::Result<::grpcio::ClientSStreamReceiver<HealthCheckResponse>,> { self.watch_opt(req, ::grpcio::CallOption::default()) }
-pub fn spawn<F>(&self, f: F) where F: ::futures::Future<Output = ()> + Send + 'static {self.client.spawn(f)}
+pub fn spawn<F>(&self, f: F) where F: ::std::future::Future<Output = ()> + Send + 'static {self.client.spawn(f)}
 }
 pub trait Health {
 fn check(&mut self, ctx: ::grpcio::RpcContext, _req: HealthCheckRequest, sink: ::grpcio::UnarySink<HealthCheckResponse>) { grpcio::unimplemented_call!(ctx, sink) }

--- a/health/src/proto/protobuf/health_grpc.rs
+++ b/health/src/proto/protobuf/health_grpc.rs
@@ -65,7 +65,7 @@ impl HealthClient {
     pub fn watch(&self, req: &super::health::HealthCheckRequest) -> ::grpcio::Result<::grpcio::ClientSStreamReceiver<super::health::HealthCheckResponse>> {
         self.watch_opt(req, ::grpcio::CallOption::default())
     }
-    pub fn spawn<F>(&self, f: F) where F: ::futures::Future<Output = ()> + Send + 'static {
+    pub fn spawn<F>(&self, f: F) where F: ::std::future::Future<Output = ()> + Send + 'static {
         self.client.spawn(f)
     }
 }

--- a/health/src/service.rs
+++ b/health/src/service.rs
@@ -1,7 +1,7 @@
 // Copyright 2021 TiKV Project Authors. Licensed under Apache-2.0.
 
 use crate::proto::{Health, HealthCheckRequest, HealthCheckResponse, ServingStatus};
-use futures::{FutureExt, SinkExt, Stream, StreamExt};
+use futures_util::{FutureExt as _, SinkExt as _, Stream, StreamExt as _};
 use grpcio::{RpcContext, RpcStatus, RpcStatusCode, ServerStreamingSink, UnarySink, WriteFlags};
 use log::info;
 use std::collections::hash_map::Entry;

--- a/health/tests/health_check.rs
+++ b/health/tests/health_check.rs
@@ -1,7 +1,7 @@
 // Copyright 2021 TiKV Project Authors. Licensed under Apache-2.0.
 
-use futures::executor::block_on;
-use futures::prelude::*;
+use futures_executor::block_on;
+use futures_util::StreamExt as _;
 use grpcio::*;
 use grpcio_health::proto::*;
 use grpcio_health::*;

--- a/interop/Cargo.toml
+++ b/interop/Cargo.toml
@@ -9,7 +9,8 @@ grpcio = { path = ".." }
 grpcio-sys = { path = "../grpc-sys" }
 grpcio-proto = { path = "../proto" }
 protobuf = "2"
-futures = "0.3"
+futures-executor = "0.3"
+futures-util = { version = "0.3", default-features = false, features = ["std"] }
 log = "0.4"
 clap = "2.23"
 futures-timer = "3.0"
@@ -21,4 +22,3 @@ path = "src/bin/client.rs"
 [[bin]]
 name = "interop_server"
 path = "src/bin/server.rs"
-

--- a/interop/src/bin/client.rs
+++ b/interop/src/bin/client.rs
@@ -8,7 +8,6 @@ extern crate interop;
 use crate::grpc::{ChannelBuilder, ChannelCredentialsBuilder, Environment};
 use crate::grpc_proto::util;
 use clap::{App, Arg};
-use futures::executor;
 use std::sync::Arc;
 
 use interop::Client;
@@ -84,7 +83,7 @@ fn main() {
     };
 
     let client = Client::new(channel);
-    executor::block_on(run_test(client, case)).unwrap();
+    futures_executor::block_on(run_test(client, case)).unwrap();
 }
 
 async fn run_test(client: Client, case: Option<&str>) -> grpcio::Result<()> {

--- a/interop/src/bin/server.rs
+++ b/interop/src/bin/server.rs
@@ -1,17 +1,14 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
-extern crate clap;
-extern crate futures;
 extern crate grpcio as grpc;
 extern crate grpcio_proto as grpc_proto;
-extern crate interop;
 #[macro_use]
 extern crate log;
 
 use std::sync::Arc;
 
 use clap::{App, Arg};
-use futures::executor::block_on;
+use futures_executor::block_on;
 use grpc::{Environment, ServerBuilder};
 use grpc_proto::testing::test_grpc::create_test_service;
 use grpc_proto::util;
@@ -64,5 +61,5 @@ fn main() {
     }
     server.start();
 
-    block_on(futures::future::pending::<()>());
+    block_on(futures_util::future::pending::<()>());
 }

--- a/interop/src/client.rs
+++ b/interop/src/client.rs
@@ -3,7 +3,7 @@
 use std::time::Duration;
 
 use crate::grpc::{self, CallOption, Channel, RpcStatusCode, WriteFlags};
-use futures::prelude::*;
+use futures_util::{SinkExt as _, TryStreamExt as _};
 
 use grpc_proto::testing::empty::Empty;
 use grpc_proto::testing::messages::{

--- a/interop/src/server.rs
+++ b/interop/src/server.rs
@@ -6,8 +6,8 @@ use crate::grpc::{
     self, ClientStreamingSink, DuplexSink, RequestStream, RpcContext, RpcStatus,
     ServerStreamingSink, UnarySink, WriteFlags,
 };
-use futures::prelude::*;
 use futures_timer::Delay;
+use futures_util::{FutureExt as _, SinkExt as _, TryFutureExt as _, TryStreamExt as _};
 
 use grpc_proto::testing::empty::Empty;
 use grpc_proto::testing::messages::{

--- a/interop/tests/tests.rs
+++ b/interop/tests/tests.rs
@@ -44,7 +44,7 @@ macro_rules! mk_test {
         mod $func {
             use std::sync::Arc;
 
-            use futures::executor::block_on;
+            use futures_executor::block_on;
             use grpc::{ChannelBuilder, Environment, ServerBuilder};
             use grpc_proto::testing::test_grpc::create_test_service;
             use grpc_proto::util;

--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -19,7 +19,6 @@ prost-codec = ["prost-derive", "prost-types", "bytes", "lazy_static", "grpcio/pr
 use-bindgen = ["grpcio/use-bindgen"]
 
 [dependencies]
-futures = "0.3"
 grpcio = { path = "..", features = ["secure"], version = "0.9.0", default-features = false }
 bytes = { version = "1.0", optional = true }
 prost = { version = "0.8", optional = true }

--- a/src/call/client.rs
+++ b/src/call/client.rs
@@ -1,17 +1,15 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
+use std::future::Future;
 use std::pin::Pin;
 use std::ptr;
 use std::sync::Arc;
+use std::task::{Context, Poll};
 use std::time::Duration;
 
 use crate::grpc_sys;
-use futures::ready;
-use futures::sink::Sink;
-use futures::stream::Stream;
-use futures::task::{Context, Poll};
+use futures_util::{ready, Sink, Stream};
 use parking_lot::Mutex;
-use std::future::Future;
 
 use super::{ShareCall, ShareCallHolder, SinkBase, WriteFlags};
 use crate::buf::GrpcSlice;

--- a/src/call/mod.rs
+++ b/src/call/mod.rs
@@ -4,15 +4,15 @@ pub mod client;
 pub mod server;
 
 use std::fmt::{self, Debug, Display};
+use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
+use std::task::{Context, Poll};
 use std::{ptr, slice};
 
 use crate::grpc_sys::{self, grpc_call, grpc_call_error, grpcwrap_batch_context};
 use crate::{cq::CompletionQueue, Metadata, MetadataBuilder};
-use futures::future::Future;
-use futures::ready;
-use futures::task::{Context, Poll};
+use futures_util::ready;
 use libc::c_void;
 use parking_lot::Mutex;
 

--- a/src/call/server.rs
+++ b/src/call/server.rs
@@ -1,19 +1,18 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
 use std::ffi::CStr;
+use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
+use std::task::{Context, Poll};
 use std::time::Duration;
 use std::{result, slice};
 
 use crate::grpc_sys::{
     self, gpr_clock_type, gpr_timespec, grpc_call_error, grpcwrap_request_call_context,
 };
-use futures::future::Future;
-use futures::ready;
-use futures::sink::Sink;
-use futures::stream::Stream;
-use futures::task::{Context, Poll};
+use futures_util::ready;
+use futures_util::{Sink, Stream};
 use parking_lot::Mutex;
 
 use super::{RpcStatus, ShareCall, ShareCallHolder, WriteFlags};

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,5 +1,7 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
+use std::future::Future;
+
 use crate::call::client::{
     CallOption, ClientCStreamReceiver, ClientCStreamSender, ClientDuplexReceiver,
     ClientDuplexSender, ClientSStreamReceiver, ClientUnaryReceiver,
@@ -9,8 +11,7 @@ use crate::channel::Channel;
 use crate::error::Result;
 use crate::task::Executor;
 use crate::task::Kicker;
-use futures::executor::block_on;
-use futures::Future;
+use futures_executor::block_on;
 
 /// A generic client for making RPC calls.
 #[derive(Clone)]
@@ -29,7 +30,7 @@ impl Client {
 
     /// Create a synchronized unary RPC call.
     ///
-    /// It uses futures::executor::block_on to wait for the futures. It's recommended to use
+    /// It uses futures_executor::block_on to wait for the futures. It's recommended to use
     /// the asynchronous version.
     pub fn unary_call<Req, Resp>(
         &self,

--- a/src/server.rs
+++ b/src/server.rs
@@ -3,16 +3,16 @@
 use std::cell::UnsafeCell;
 use std::collections::HashMap;
 use std::fmt::{self, Debug, Formatter};
+use std::future::Future;
 use std::net::{IpAddr, SocketAddr};
 use std::pin::Pin;
 use std::ptr;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
+use std::task::{Context, Poll};
 
 use crate::grpc_sys::{self, grpc_call_error, grpc_server};
-use futures::future::Future;
-use futures::ready;
-use futures::task::{Context, Poll};
+use futures_util::ready;
 
 use crate::call::server::*;
 use crate::call::{MessageReader, Method, MethodType};
@@ -635,7 +635,7 @@ impl Drop for Server {
             None
         };
         self.cancel_all_calls();
-        let _ = f.map(futures::executor::block_on);
+        let _ = f.map(futures_executor::block_on);
     }
 }
 

--- a/src/task/executor.rs
+++ b/src/task/executor.rs
@@ -8,12 +8,13 @@
 //! same completion queue as its inner call. Hence method `Executor::spawn` is provided.
 
 use std::cell::UnsafeCell;
+use std::future::Future;
 use std::pin::Pin;
 use std::sync::atomic::{AtomicU8, Ordering};
 use std::sync::Arc;
+use std::task::{Context, Poll};
 
-use futures::future::Future;
-use futures::task::{waker_ref, ArcWake, Context, Poll};
+use futures_util::task::{waker_ref, ArcWake};
 
 use super::CallTag;
 use crate::call::Call;

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -5,11 +5,11 @@ mod executor;
 mod promise;
 
 use std::fmt::{self, Debug, Formatter};
+use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
+use std::task::{Context, Poll, Waker};
 
-use futures::future::Future;
-use futures::task::{Context, Poll, Waker};
 use parking_lot::Mutex;
 
 use self::callback::{Abort, Request as RequestCallback, UnaryRequest as UnaryRequestCallback};
@@ -203,7 +203,7 @@ mod tests {
 
     use super::*;
     use crate::env::Environment;
-    use futures::executor::block_on;
+    use futures_executor::block_on;
 
     #[test]
     fn test_resolve() {

--- a/tests-and-examples/Cargo.toml
+++ b/tests-and-examples/Cargo.toml
@@ -13,7 +13,9 @@ prost-codec = ["prost", "bytes", "grpcio/prost-codec", "grpcio-proto/prost-codec
 [dependencies]
 grpcio-sys = { path = "../grpc-sys", version = "0.9" }
 libc = "0.2"
-futures = "0.3"
+futures-channel = { version = "0.3", features = ["sink"] }
+futures-executor = "0.3"
+futures-util = { version = "0.3", features = ["sink"] }
 futures-timer = "3.0"
 protobuf = { version = "2.22", optional = true }
 prost = { version = "0.8", optional = true }

--- a/tests-and-examples/examples/hello_world/server.rs
+++ b/tests-and-examples/examples/hello_world/server.rs
@@ -10,9 +10,9 @@ use std::io::Read;
 use std::sync::Arc;
 use std::{io, thread};
 
-use futures::channel::oneshot;
-use futures::executor::block_on;
-use futures::prelude::*;
+use futures_channel::oneshot;
+use futures_executor::block_on;
+use futures_util::future::{FutureExt as _, TryFutureExt as _};
 use grpcio::{ChannelBuilder, Environment, ResourceQuota, RpcContext, ServerBuilder, UnarySink};
 
 use grpcio_proto::example::helloworld::{HelloReply, HelloRequest};

--- a/tests-and-examples/examples/load_balancing/server.rs
+++ b/tests-and-examples/examples/load_balancing/server.rs
@@ -10,9 +10,9 @@ use std::io::Read;
 use std::sync::Arc;
 use std::{io, thread};
 
-use futures::channel::oneshot;
-use futures::executor::block_on;
-use futures::prelude::*;
+use futures_channel::oneshot;
+use futures_executor::block_on;
+use futures_util::future::{FutureExt as _, TryFutureExt as _};
 use grpcio::{
     ChannelBuilder, Environment, ResourceQuota, RpcContext, Server, ServerBuilder, UnarySink,
 };

--- a/tests-and-examples/examples/route_guide/client.rs
+++ b/tests-and-examples/examples/route_guide/client.rs
@@ -14,7 +14,7 @@ use std::sync::Arc;
 use std::thread;
 use std::time::Duration;
 
-use futures::prelude::*;
+use futures_util::{SinkExt as _, TryStreamExt as _};
 use grpcio::*;
 use grpcio_proto::example::route_guide::{Point, Rectangle, RouteNote};
 use grpcio_proto::example::route_guide_grpc::RouteGuideClient;
@@ -129,7 +129,7 @@ async fn route_chat(client: &RouteGuideClient) -> Result<()> {
         }
         Ok(()) as Result<_>
     };
-    let (sr, rr) = futures::join!(send, receive);
+    let (sr, rr) = futures_util::join!(send, receive);
     sr.and(rr)?;
     Ok(())
 }
@@ -157,5 +157,5 @@ async fn async_main() -> Result<()> {
 }
 
 fn main() {
-    futures::executor::block_on(async_main()).unwrap()
+    futures_executor::block_on(async_main()).unwrap()
 }

--- a/tests-and-examples/examples/route_guide/server.rs
+++ b/tests-and-examples/examples/route_guide/server.rs
@@ -14,9 +14,9 @@ use std::sync::{Arc, Mutex};
 use std::time::Instant;
 use std::{io, thread};
 
-use futures::channel::oneshot;
-use futures::executor::block_on;
-use futures::prelude::*;
+use futures_channel::oneshot;
+use futures_executor::block_on;
+use futures_util::{FutureExt as _, SinkExt as _, TryFutureExt as _, TryStreamExt as _};
 use grpcio::*;
 
 use crate::util::*;

--- a/tests-and-examples/tests/cases/auth_context.rs
+++ b/tests-and-examples/tests/cases/auth_context.rs
@@ -1,6 +1,6 @@
 // Copyright 2020 TiKV Project Authors. Licensed under Apache-2.0.
 
-use futures::*;
+use futures_util::future::{FutureExt as _, TryFutureExt as _};
 use grpcio::*;
 use grpcio_proto::example::helloworld::*;
 

--- a/tests-and-examples/tests/cases/credential.rs
+++ b/tests-and-examples/tests/cases/credential.rs
@@ -1,6 +1,7 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
-use futures::prelude::*;
+use futures_util::future::{FutureExt as _, TryFutureExt as _};
+
 use grpcio::{
     CertificateRequestType, ChannelBuilder, ChannelCredentialsBuilder, EnvBuilder, RpcContext,
     ServerBuilder, ServerCredentialsBuilder, ServerCredentialsFetcher, UnarySink,

--- a/tests-and-examples/tests/cases/kick.rs
+++ b/tests-and-examples/tests/cases/kick.rs
@@ -1,13 +1,14 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
-use futures::channel::oneshot::{self, Sender};
-use futures::executor::block_on;
-use futures::prelude::*;
-use futures::task::*;
+use futures_channel::oneshot::{self, Sender};
+use futures_executor::block_on;
+use futures_util::future::{FutureExt as _, TryFutureExt as _};
 use grpcio::*;
 use grpcio_proto::example::helloworld::*;
+use std::future::Future;
 use std::pin::Pin;
 use std::sync::*;
+use std::task::{Context, Poll, Waker};
 use std::thread;
 use std::time::*;
 

--- a/tests-and-examples/tests/cases/metadata.rs
+++ b/tests-and-examples/tests/cases/metadata.rs
@@ -1,6 +1,6 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
-use futures::*;
+use futures_util::future::{FutureExt as _, TryFutureExt as _};
 use grpcio::*;
 use grpcio_proto::example::helloworld::*;
 use grpcio_proto::google::rpc::Status;

--- a/tests-and-examples/tests/cases/misc.rs
+++ b/tests-and-examples/tests/cases/misc.rs
@@ -1,8 +1,8 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
-use futures::executor::block_on;
-use futures::prelude::*;
+use futures_executor::block_on;
 use futures_timer::Delay;
+use futures_util::future::{self, FutureExt as _, TryFutureExt as _};
 use grpcio::*;
 use grpcio_proto::example::helloworld::*;
 use std::sync::atomic::*;
@@ -141,7 +141,7 @@ fn test_soundness() {
             for _ in 0..3000 {
                 resps.push(client.say_hello_async(&HelloRequest::default()).unwrap());
             }
-            block_on(futures::future::try_join_all(resps)).unwrap();
+            block_on(future::try_join_all(resps)).unwrap();
         })
     };
     let j1 = spawn_reqs(env.clone());

--- a/tests-and-examples/tests/cases/stream.rs
+++ b/tests-and-examples/tests/cases/stream.rs
@@ -2,12 +2,13 @@
 
 use std::sync::Arc;
 
-use futures::channel::mpsc;
-use futures::executor::block_on;
-use futures::join;
-use futures::prelude::*;
-use futures::sink::SinkExt;
+use futures_channel::mpsc;
+use futures_executor::block_on;
 use futures_timer::Delay;
+use futures_util::{join, stream};
+use futures_util::{
+    FutureExt as _, SinkExt as _, StreamExt as _, TryFutureExt as _, TryStreamExt as _,
+};
 use grpcio::{
     ChannelBuilder, ClientStreamingSink, DuplexSink, EnvBuilder, RequestStream, RpcContext,
     ServerBuilder, ServerStreamingSink, UnarySink, WriteFlags,
@@ -100,7 +101,7 @@ fn test_client_send_all() {
             p.set_longitude(i);
             send_data.push(p);
         }
-        let send_stream = futures::stream::iter(send_data);
+        let send_stream = stream::iter(send_data);
         assert_finish!(
             sink.send_all(&mut send_stream.map(move |item| Ok((item, WriteFlags::default()))))
                 .await
@@ -116,7 +117,7 @@ fn test_client_send_all() {
             p.set_longitude(i);
             send_data.push(p);
         }
-        let send_stream = futures::stream::iter(send_data);
+        let send_stream = stream::iter(send_data);
         sink.enhance_batch(true);
         assert_finish!(
             sink.send_all(&mut send_stream.map(move |item| Ok((item, WriteFlags::default()))))
@@ -133,7 +134,7 @@ fn test_client_send_all() {
             p.set_longitude(i);
             send_data.push(p);
         }
-        let send_stream = futures::stream::iter(send_data);
+        let send_stream = stream::iter(send_data);
         sink.enhance_batch(false);
         sink.send_all(
             &mut send_stream.map(move |item| Ok((item, WriteFlags::default().buffer_hint(true)))),


### PR DESCRIPTION
Reduces dependency graph of each crate:

| |before|after|
-|-|-
grpcio|50|30
benchmark|120|102
grpcio-compiler|2|2
grpcio-health|54|35
interop|71|51
grpcio-proto|54|33
tests-and-examples|63|57


A particularly important change has been made to the `compiler` crate which now references the `Future` trait directly from `std` rather than it's re-export through the futures crate, meaning that downstream crates can also move away from having a direct dependency on `futures`.