### PR TITLE
metadata: avoid change metadata ref

### DIFF
--- a/grpc-sys/grpc_wrap.cc
+++ b/grpc-sys/grpc_wrap.cc
@@ -283,16 +283,6 @@ grpcwrap_request_call_context_destroy(grpcwrap_request_call_context* ctx) {
 GPR_EXPORT void GPR_CALLTYPE grpcwrap_batch_context_take_recv_initial_metadata(
     grpcwrap_batch_context* ctx, grpc_metadata_array* res) {
   grpcwrap_metadata_array_move(res, &(ctx->recv_initial_metadata));
-
-  /* According to the documentation for struct grpc_op in grpc_types.h,
-   * ownership of keys and values for
-   * metadata stays with the call object. This means we have ref each of the
-   * keys and values here. */
-  size_t i;
-  for (i = 0; i < res->count; i++) {
-    grpc_slice_ref(res->metadata[i].key);
-    grpc_slice_ref(res->metadata[i].value);
-  }
 }
 
 GPR_EXPORT void GPR_CALLTYPE
@@ -300,16 +290,6 @@ grpcwrap_batch_context_take_recv_status_on_client_trailing_metadata(
     grpcwrap_batch_context* ctx, grpc_metadata_array* res) {
   grpcwrap_metadata_array_move(res,
                                &(ctx->recv_status_on_client.trailing_metadata));
-
-  /* According to the documentation for struct grpc_op in grpc_types.h,
-   * ownership of keys and values for
-   * metadata stays with the call object. This means we have ref each of the
-   * keys and values here. */
-  size_t i;
-  for (i = 0; i < res->count; i++) {
-    grpc_slice_ref(res->metadata[i].key);
-    grpc_slice_ref(res->metadata[i].value);
-  }
 }
 
 GPR_EXPORT const char* GPR_CALLTYPE

--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -27,5 +27,5 @@ protobuf = "2"
 lazy_static = { version = "1.3", optional = true }
 
 [build-dependencies]
-protobuf-build = { version = ">=0.12", default-features = false }
+protobuf-build = { version = ">=0.13", default-features = false }
 walkdir = "2.2"

--- a/src/buf.rs
+++ b/src/buf.rs
@@ -15,7 +15,7 @@ const INLINED_SIZE: usize = mem::size_of::<libc::size_t>() + mem::size_of::<*mut
 /// A convenient rust wrapper for the type `grpc_slice`.
 ///
 /// It's expected that the slice should be initialized.
-#[repr(C)]
+#[repr(transparent)]
 pub struct GrpcSlice(grpc_slice);
 
 impl GrpcSlice {

--- a/src/call/mod.rs
+++ b/src/call/mod.rs
@@ -11,6 +11,7 @@ use std::task::{Context, Poll};
 use std::{ptr, slice};
 
 use crate::grpc_sys::{self, grpc_call, grpc_call_error, grpcwrap_batch_context};
+use crate::metadata::UnownedMetadata;
 use crate::{cq::CompletionQueue, Metadata, MetadataBuilder};
 use futures_util::ready;
 use libc::c_void;
@@ -291,8 +292,8 @@ impl BatchContext {
     ///
     /// If initial metadata is not fetched or the method has been called, empty metadata will be
     /// returned.
-    pub fn take_initial_metadata(&mut self) -> Metadata {
-        let mut res = MetadataBuilder::with_capacity(0).build();
+    pub fn take_initial_metadata(&mut self) -> UnownedMetadata {
+        let mut res = UnownedMetadata::empty();
         unsafe {
             grpcio_sys::grpcwrap_batch_context_take_recv_initial_metadata(
                 self.ctx,
@@ -306,8 +307,8 @@ impl BatchContext {
     ///
     /// If trailing metadata is not fetched or the method has been called, empty metadata will be
     /// returned.
-    pub fn take_trailing_metadata(&mut self) -> Metadata {
-        let mut res = MetadataBuilder::with_capacity(0).build();
+    pub fn take_trailing_metadata(&mut self) -> UnownedMetadata {
+        let mut res = UnownedMetadata::empty();
         unsafe {
             grpc_sys::grpcwrap_batch_context_take_recv_status_on_client_trailing_metadata(
                 self.ctx,

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -147,7 +147,7 @@ impl MetadataBuilder {
 ///
 /// Metadata value can be ascii string or bytes. They are distinguish by the
 /// key suffix, key of bytes value should have suffix '-bin'.
-#[repr(C)]
+#[repr(transparent)]
 pub struct Metadata(grpc_metadata_array);
 
 impl Metadata {
@@ -273,7 +273,7 @@ unsafe impl Sync for Metadata {}
 ///
 /// gRPC C Core manages metadata internally, it's unsafe to read them unless
 /// call is not destroyed.
-#[repr(C)]
+#[repr(transparent)]
 pub struct UnownedMetadata(grpc_metadata_array);
 
 impl UnownedMetadata {

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -234,10 +234,6 @@ impl Metadata {
         }
         &[]
     }
-
-    pub(crate) fn as_mut_ptr(&mut self) -> *mut grpc_metadata_array {
-        &mut self.0 as _
-    }
 }
 
 impl fmt::Debug for Metadata {
@@ -272,6 +268,38 @@ impl Drop for Metadata {
 
 unsafe impl Send for Metadata {}
 unsafe impl Sync for Metadata {}
+
+/// A special metadata that only for receiving metadata from remote.
+///
+/// gRPC C Core manages metadata internally, it's unsafe to read them unless
+/// call is not destroyed.
+#[repr(C)]
+pub struct UnownedMetadata(grpc_metadata_array);
+
+impl UnownedMetadata {
+    #[inline]
+    pub fn empty() -> UnownedMetadata {
+        unsafe { mem::transmute(Metadata::with_capacity(0)) }
+    }
+    #[inline]
+    pub unsafe fn assume_valid(&self) -> &Metadata {
+        mem::transmute(self)
+    }
+
+    pub fn as_mut_ptr(&mut self) -> *mut grpc_metadata_array {
+        &mut self.0 as _
+    }
+}
+
+impl Drop for UnownedMetadata {
+    #[inline]
+    fn drop(&mut self) {
+        unsafe { grpcio_sys::grpcwrap_metadata_array_destroy_metadata_only(&mut self.0) }
+    }
+}
+
+unsafe impl Send for UnownedMetadata {}
+unsafe impl Sync for UnownedMetadata {}
 
 /// Immutable metadata iterator
 ///

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -22,7 +22,7 @@ use crate::error::{Error, Result};
 use crate::server::RequestCallContext;
 
 pub(crate) use self::executor::{Executor, Kicker, UnfinishedWork};
-pub use self::promise::BatchResult;
+pub(crate) use self::promise::BatchResult;
 pub use self::promise::BatchType;
 
 /// A handle that is used to notify future that the task finishes.

--- a/src/task/promise.rs
+++ b/src/task/promise.rs
@@ -109,7 +109,6 @@ impl Batch {
         let task = {
             let mut guard = self.inner.lock();
             let status = self.ctx.rpc_status();
-            eprintln!("{:?}", status);
             if status.code() == RpcStatusCode::OK {
                 guard.set_result(Ok(BatchResult::new(
                     self.ctx.recv_message(),


### PR DESCRIPTION
After metadata is received, every entry should be owned by the grpc c
core, application should clone the byte slice if necessary.

In the past, we get around the problem by increasing the reference
count of the slice. However, it's unsafe to do so as the slice is not
guaranteed to be accessible in the first place.

This PR fixes the problem by introducing an unowned metadata type. It
works just like Metadata, but accessing its content requires manual
check for the lifetime of associated call.

I tried to add test case to cover the unsafe access, however it's too racy
and nearly impossible to introduce a case without touching the C core.