### PR TITLE
*: remove arm ci check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,9 +35,6 @@ jobs:
           - host: ubuntu-latest
             profile: 
             suffix:
-          - host: ARM64
-            profile: --release
-            suffix: -Arm64
     name: Linux-Stable${{ matrix.suffix }}
     runs-on: ${{ matrix.host }}
     steps:
@@ -62,9 +59,6 @@ jobs:
           - host: ubuntu-latest
             profile: 
             suffix:
-          - host: ARM64
-            profile: --release
-            suffix: -Arm64
     name: Linux-Stable-openssl${{ matrix.suffix }}
     runs-on: ${{ matrix.host }}
     steps:


### PR DESCRIPTION
Confirmed from pingcap that arm self hosted runner is not available anymore, so we need to remove these checks in CI as they will always timeout.