### PR TITLE
client: allow accessing channel

### DIFF
--- a/compiler/src/codegen.rs
+++ b/compiler/src/codegen.rs
@@ -575,7 +575,10 @@ impl<'a> ServiceGen<'a> {
     fn write_client(&self, w: &mut CodeWriter) {
         w.write_line("#[derive(Clone)]");
         w.pub_struct(&self.client_name(), |w| {
-            w.field_decl("client", "::grpcio::Client");
+            // This can also be exposed by a method. But it may introduce a name conflict
+            // between service definition and method name. Marking it public may put extra
+            // restrict on compatability, but it should not be an issue.
+            w.field_decl("pub client", "::grpcio::Client");
         });
 
         w.write_line("");

--- a/compiler/src/prost_codegen.rs
+++ b/compiler/src/prost_codegen.rs
@@ -167,7 +167,7 @@ fn generate_client(service: &Service, buf: &mut String) {
     buf.push_str("#[derive(Clone)]\n");
     buf.push_str("pub struct ");
     buf.push_str(&client_name);
-    buf.push_str(" { client: ::grpcio::Client }\n");
+    buf.push_str(" { pub client: ::grpcio::Client }\n");
 
     buf.push_str("impl ");
     buf.push_str(&client_name);

--- a/health/src/proto/prost/grpc.health.v1.rs
+++ b/health/src/proto/prost/grpc.health.v1.rs
@@ -1,16 +1,26 @@
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct HealthCheckRequest {
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub service: ::prost::alloc::string::String,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct HealthCheckResponse {
-    #[prost(enumeration="health_check_response::ServingStatus", tag="1")]
+    #[prost(enumeration = "health_check_response::ServingStatus", tag = "1")]
     pub status: i32,
 }
 /// Nested message and enum types in `HealthCheckResponse`.
 pub mod health_check_response {
-    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+    #[derive(
+        Clone,
+        Copy,
+        Debug,
+        PartialEq,
+        Eq,
+        Hash,
+        PartialOrd,
+        Ord,
+        ::prost::Enumeration
+    )]
     #[repr(i32)]
     pub enum ServingStatus {
         Unknown = 0,
@@ -34,29 +44,117 @@ pub mod health_check_response {
         }
     }
 }
-const METHOD_HEALTH_CHECK: ::grpcio::Method<HealthCheckRequest, HealthCheckResponse> = ::grpcio::Method{ty: ::grpcio::MethodType::Unary, name: "/grpc.health.v1.Health/Check", req_mar: ::grpcio::Marshaller { ser: ::grpcio::pr_ser, de: ::grpcio::pr_de }, resp_mar: ::grpcio::Marshaller { ser: ::grpcio::pr_ser, de: ::grpcio::pr_de }, };
-const METHOD_HEALTH_WATCH: ::grpcio::Method<HealthCheckRequest, HealthCheckResponse> = ::grpcio::Method{ty: ::grpcio::MethodType::ServerStreaming, name: "/grpc.health.v1.Health/Watch", req_mar: ::grpcio::Marshaller { ser: ::grpcio::pr_ser, de: ::grpcio::pr_de }, resp_mar: ::grpcio::Marshaller { ser: ::grpcio::pr_ser, de: ::grpcio::pr_de }, };
+const METHOD_HEALTH_CHECK: ::grpcio::Method<HealthCheckRequest, HealthCheckResponse> = ::grpcio::Method {
+    ty: ::grpcio::MethodType::Unary,
+    name: "/grpc.health.v1.Health/Check",
+    req_mar: ::grpcio::Marshaller {
+        ser: ::grpcio::pr_ser,
+        de: ::grpcio::pr_de,
+    },
+    resp_mar: ::grpcio::Marshaller {
+        ser: ::grpcio::pr_ser,
+        de: ::grpcio::pr_de,
+    },
+};
+const METHOD_HEALTH_WATCH: ::grpcio::Method<HealthCheckRequest, HealthCheckResponse> = ::grpcio::Method {
+    ty: ::grpcio::MethodType::ServerStreaming,
+    name: "/grpc.health.v1.Health/Watch",
+    req_mar: ::grpcio::Marshaller {
+        ser: ::grpcio::pr_ser,
+        de: ::grpcio::pr_de,
+    },
+    resp_mar: ::grpcio::Marshaller {
+        ser: ::grpcio::pr_ser,
+        de: ::grpcio::pr_de,
+    },
+};
 #[derive(Clone)]
-pub struct HealthClient { client: ::grpcio::Client }
+pub struct HealthClient {
+    pub client: ::grpcio::Client,
+}
 impl HealthClient {
-pub fn new(channel: ::grpcio::Channel) -> Self { HealthClient { client: ::grpcio::Client::new(channel) }}
-pub fn check_opt(&self, req: &HealthCheckRequest, opt: ::grpcio::CallOption) -> ::grpcio::Result<HealthCheckResponse,> { self.client.unary_call(&METHOD_HEALTH_CHECK, req, opt) }
-pub fn check(&self, req: &HealthCheckRequest) -> ::grpcio::Result<HealthCheckResponse,> { self.check_opt(req, ::grpcio::CallOption::default()) }
-pub fn check_async_opt(&self, req: &HealthCheckRequest, opt: ::grpcio::CallOption) -> ::grpcio::Result<::grpcio::ClientUnaryReceiver<HealthCheckResponse>,> { self.client.unary_call_async(&METHOD_HEALTH_CHECK, req, opt) }
-pub fn check_async(&self, req: &HealthCheckRequest) -> ::grpcio::Result<::grpcio::ClientUnaryReceiver<HealthCheckResponse>,> { self.check_async_opt(req, ::grpcio::CallOption::default()) }
-pub fn watch_opt(&self, req: &HealthCheckRequest, opt: ::grpcio::CallOption) -> ::grpcio::Result<::grpcio::ClientSStreamReceiver<HealthCheckResponse>,> { self.client.server_streaming(&METHOD_HEALTH_WATCH, req, opt) }
-pub fn watch(&self, req: &HealthCheckRequest) -> ::grpcio::Result<::grpcio::ClientSStreamReceiver<HealthCheckResponse>,> { self.watch_opt(req, ::grpcio::CallOption::default()) }
-pub fn spawn<F>(&self, f: F) where F: ::std::future::Future<Output = ()> + Send + 'static {self.client.spawn(f)}
+    pub fn new(channel: ::grpcio::Channel) -> Self {
+        HealthClient {
+            client: ::grpcio::Client::new(channel),
+        }
+    }
+    pub fn check_opt(
+        &self,
+        req: &HealthCheckRequest,
+        opt: ::grpcio::CallOption,
+    ) -> ::grpcio::Result<HealthCheckResponse> {
+        self.client.unary_call(&METHOD_HEALTH_CHECK, req, opt)
+    }
+    pub fn check(
+        &self,
+        req: &HealthCheckRequest,
+    ) -> ::grpcio::Result<HealthCheckResponse> {
+        self.check_opt(req, ::grpcio::CallOption::default())
+    }
+    pub fn check_async_opt(
+        &self,
+        req: &HealthCheckRequest,
+        opt: ::grpcio::CallOption,
+    ) -> ::grpcio::Result<::grpcio::ClientUnaryReceiver<HealthCheckResponse>> {
+        self.client.unary_call_async(&METHOD_HEALTH_CHECK, req, opt)
+    }
+    pub fn check_async(
+        &self,
+        req: &HealthCheckRequest,
+    ) -> ::grpcio::Result<::grpcio::ClientUnaryReceiver<HealthCheckResponse>> {
+        self.check_async_opt(req, ::grpcio::CallOption::default())
+    }
+    pub fn watch_opt(
+        &self,
+        req: &HealthCheckRequest,
+        opt: ::grpcio::CallOption,
+    ) -> ::grpcio::Result<::grpcio::ClientSStreamReceiver<HealthCheckResponse>> {
+        self.client.server_streaming(&METHOD_HEALTH_WATCH, req, opt)
+    }
+    pub fn watch(
+        &self,
+        req: &HealthCheckRequest,
+    ) -> ::grpcio::Result<::grpcio::ClientSStreamReceiver<HealthCheckResponse>> {
+        self.watch_opt(req, ::grpcio::CallOption::default())
+    }
+    pub fn spawn<F>(&self, f: F)
+    where
+        F: ::std::future::Future<Output = ()> + Send + 'static,
+    {
+        self.client.spawn(f)
+    }
 }
 pub trait Health {
-fn check(&mut self, ctx: ::grpcio::RpcContext, _req: HealthCheckRequest, sink: ::grpcio::UnarySink<HealthCheckResponse>) { grpcio::unimplemented_call!(ctx, sink) }
-fn watch(&mut self, ctx: ::grpcio::RpcContext, _req: HealthCheckRequest, sink: ::grpcio::ServerStreamingSink<HealthCheckResponse>) { grpcio::unimplemented_call!(ctx, sink) }
+    fn check(
+        &mut self,
+        ctx: ::grpcio::RpcContext,
+        _req: HealthCheckRequest,
+        sink: ::grpcio::UnarySink<HealthCheckResponse>,
+    ) {
+        grpcio::unimplemented_call!(ctx, sink)
+    }
+    fn watch(
+        &mut self,
+        ctx: ::grpcio::RpcContext,
+        _req: HealthCheckRequest,
+        sink: ::grpcio::ServerStreamingSink<HealthCheckResponse>,
+    ) {
+        grpcio::unimplemented_call!(ctx, sink)
+    }
 }
 pub fn create_health<S: Health + Send + Clone + 'static>(s: S) -> ::grpcio::Service {
-let mut builder = ::grpcio::ServiceBuilder::new();
-let mut instance = s.clone();
-builder = builder.add_unary_handler(&METHOD_HEALTH_CHECK, move |ctx, req, resp| instance.check(ctx, req, resp));
-let mut instance = s;
-builder = builder.add_server_streaming_handler(&METHOD_HEALTH_WATCH, move |ctx, req, resp| instance.watch(ctx, req, resp));
-builder.build()
+    let mut builder = ::grpcio::ServiceBuilder::new();
+    let mut instance = s.clone();
+    builder = builder
+        .add_unary_handler(
+            &METHOD_HEALTH_CHECK,
+            move |ctx, req, resp| instance.check(ctx, req, resp),
+        );
+    let mut instance = s;
+    builder = builder
+        .add_server_streaming_handler(
+            &METHOD_HEALTH_WATCH,
+            move |ctx, req, resp| instance.watch(ctx, req, resp),
+        );
+    builder.build()
 }

--- a/health/src/proto/protobuf/health_grpc.rs
+++ b/health/src/proto/protobuf/health_grpc.rs
@@ -49,7 +49,7 @@ const METHOD_HEALTH_WATCH: ::grpcio::Method<
 
 #[derive(Clone)]
 pub struct HealthClient {
-    client: ::grpcio::Client,
+    pub client: ::grpcio::Client,
 }
 
 impl HealthClient {

--- a/proto/src/proto/prost/example/helloworld.rs
+++ b/proto/src/proto/prost/example/helloworld.rs
@@ -24,7 +24,7 @@ const METHOD_GREETER_SAY_HELLO: ::grpcio::Method<HelloRequest, HelloReply> = ::g
 };
 #[derive(Clone)]
 pub struct GreeterClient {
-    client: ::grpcio::Client,
+    pub client: ::grpcio::Client,
 }
 impl GreeterClient {
     pub fn new(channel: ::grpcio::Channel) -> Self {

--- a/proto/src/proto/prost/example/routeguide.rs
+++ b/proto/src/proto/prost/example/routeguide.rs
@@ -112,7 +112,7 @@ const METHOD_ROUTE_GUIDE_ROUTE_CHAT: ::grpcio::Method<RouteNote, RouteNote> = ::
 };
 #[derive(Clone)]
 pub struct RouteGuideClient {
-    client: ::grpcio::Client,
+    pub client: ::grpcio::Client,
 }
 impl RouteGuideClient {
     pub fn new(channel: ::grpcio::Channel) -> Self {

--- a/proto/src/proto/prost/testing/grpc.testing.rs
+++ b/proto/src/proto/prost/testing/grpc.testing.rs
@@ -264,7 +264,6 @@ pub struct ServerConfig {
     /// Number of threads that share each completion queue
     #[prost(int32, tag = "12")]
     pub threads_per_cq: i32,
-    // c++-only options (for now) --------------------------------
     /// Buffer pool size (no buffer pool specified if unset)
     #[prost(int32, tag = "1001")]
     pub resource_quota_size: i32,
@@ -752,7 +751,7 @@ const METHOD_BENCHMARK_SERVICE_STREAMING_BOTH_WAYS: ::grpcio::Method<
 };
 #[derive(Clone)]
 pub struct BenchmarkServiceClient {
-    client: ::grpcio::Client,
+    pub client: ::grpcio::Client,
 }
 impl BenchmarkServiceClient {
     pub fn new(channel: ::grpcio::Channel) -> Self {
@@ -986,7 +985,7 @@ const METHOD_WORKER_SERVICE_QUIT_WORKER: ::grpcio::Method<Void, Void> = ::grpcio
 };
 #[derive(Clone)]
 pub struct WorkerServiceClient {
-    client: ::grpcio::Client,
+    pub client: ::grpcio::Client,
 }
 impl WorkerServiceClient {
     pub fn new(channel: ::grpcio::Channel) -> Self {
@@ -1156,7 +1155,7 @@ const METHOD_REPORT_QPS_SCENARIO_SERVICE_REPORT_SCENARIO: ::grpcio::Method<Scena
     };
 #[derive(Clone)]
 pub struct ReportQpsScenarioServiceClient {
-    client: ::grpcio::Client,
+    pub client: ::grpcio::Client,
 }
 impl ReportQpsScenarioServiceClient {
     pub fn new(channel: ::grpcio::Channel) -> Self {
@@ -1335,7 +1334,7 @@ const METHOD_TEST_SERVICE_UNIMPLEMENTED_CALL: ::grpcio::Method<Empty, Empty> = :
 };
 #[derive(Clone)]
 pub struct TestServiceClient {
-    client: ::grpcio::Client,
+    pub client: ::grpcio::Client,
 }
 impl TestServiceClient {
     pub fn new(channel: ::grpcio::Channel) -> Self {
@@ -1641,7 +1640,7 @@ const METHOD_UNIMPLEMENTED_SERVICE_UNIMPLEMENTED_CALL: ::grpcio::Method<Empty, E
     };
 #[derive(Clone)]
 pub struct UnimplementedServiceClient {
-    client: ::grpcio::Client,
+    pub client: ::grpcio::Client,
 }
 impl UnimplementedServiceClient {
     pub fn new(channel: ::grpcio::Channel) -> Self {
@@ -1728,7 +1727,7 @@ const METHOD_RECONNECT_SERVICE_STOP: ::grpcio::Method<Empty, ReconnectInfo> = ::
 };
 #[derive(Clone)]
 pub struct ReconnectServiceClient {
-    client: ::grpcio::Client,
+    pub client: ::grpcio::Client,
 }
 impl ReconnectServiceClient {
     pub fn new(channel: ::grpcio::Channel) -> Self {

--- a/proto/src/proto/protobuf/example/helloworld_grpc.rs
+++ b/proto/src/proto/protobuf/example/helloworld_grpc.rs
@@ -33,7 +33,7 @@ const METHOD_GREETER_SAY_HELLO: ::grpcio::Method<
 
 #[derive(Clone)]
 pub struct GreeterClient {
-    client: ::grpcio::Client,
+    pub client: ::grpcio::Client,
 }
 
 impl GreeterClient {

--- a/proto/src/proto/protobuf/example/route_guide_grpc.rs
+++ b/proto/src/proto/protobuf/example/route_guide_grpc.rs
@@ -81,7 +81,7 @@ const METHOD_ROUTE_GUIDE_ROUTE_CHAT: ::grpcio::Method<
 
 #[derive(Clone)]
 pub struct RouteGuideClient {
-    client: ::grpcio::Client,
+    pub client: ::grpcio::Client,
 }
 
 impl RouteGuideClient {

--- a/proto/src/proto/protobuf/testing/services_grpc.rs
+++ b/proto/src/proto/protobuf/testing/services_grpc.rs
@@ -97,7 +97,7 @@ const METHOD_BENCHMARK_SERVICE_STREAMING_BOTH_WAYS: ::grpcio::Method<
 
 #[derive(Clone)]
 pub struct BenchmarkServiceClient {
-    client: ::grpcio::Client,
+    pub client: ::grpcio::Client,
 }
 
 impl BenchmarkServiceClient {
@@ -363,7 +363,7 @@ const METHOD_WORKER_SERVICE_QUIT_WORKER: ::grpcio::Method<
 
 #[derive(Clone)]
 pub struct WorkerServiceClient {
-    client: ::grpcio::Client,
+    pub client: ::grpcio::Client,
 }
 
 impl WorkerServiceClient {
@@ -562,7 +562,7 @@ const METHOD_REPORT_QPS_SCENARIO_SERVICE_REPORT_SCENARIO: ::grpcio::Method<
 
 #[derive(Clone)]
 pub struct ReportQpsScenarioServiceClient {
-    client: ::grpcio::Client,
+    pub client: ::grpcio::Client,
 }
 
 impl ReportQpsScenarioServiceClient {

--- a/proto/src/proto/protobuf/testing/test_grpc.rs
+++ b/proto/src/proto/protobuf/testing/test_grpc.rs
@@ -143,7 +143,7 @@ const METHOD_TEST_SERVICE_UNIMPLEMENTED_CALL: ::grpcio::Method<
 
 #[derive(Clone)]
 pub struct TestServiceClient {
-    client: ::grpcio::Client,
+    pub client: ::grpcio::Client,
 }
 
 impl TestServiceClient {
@@ -493,7 +493,7 @@ const METHOD_UNIMPLEMENTED_SERVICE_UNIMPLEMENTED_CALL: ::grpcio::Method<
 
 #[derive(Clone)]
 pub struct UnimplementedServiceClient {
-    client: ::grpcio::Client,
+    pub client: ::grpcio::Client,
 }
 
 impl UnimplementedServiceClient {
@@ -599,7 +599,7 @@ const METHOD_RECONNECT_SERVICE_STOP: ::grpcio::Method<
 
 #[derive(Clone)]
 pub struct ReconnectServiceClient {
-    client: ::grpcio::Client,
+    pub client: ::grpcio::Client,
 }
 
 impl ReconnectServiceClient {

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -652,7 +652,7 @@ impl Channel {
             let target = CString::new(target).unwrap();
             let ch = grpc_sys::grpc_lame_client_channel_create(
                 target.as_ptr(),
-                RpcStatusCode::INTERNAL.into(),
+                RpcStatusCode::UNAVAILABLE.into(),
                 b"call on lame client\0".as_ptr() as _,
             );
             Self::new(env.pick_cq(), env, ch)

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -21,8 +21,8 @@ use crate::env::Environment;
 use crate::error::Result;
 use crate::task::CallTag;
 use crate::task::Kicker;
-use crate::ResourceQuota;
 use crate::{CallOption, ChannelCredentials};
+use crate::{ResourceQuota, RpcStatusCode};
 
 pub use crate::grpc_sys::{
     grpc_compression_algorithm as CompressionAlgorithms,
@@ -643,6 +643,19 @@ impl Channel {
         Channel {
             inner: Arc::new(ChannelInner { _env: env, channel }),
             cq,
+        }
+    }
+
+    /// Create a lame channel that will fail all its operations.
+    pub fn lame(env: Arc<Environment>, target: &str) -> Channel {
+        unsafe {
+            let target = CString::new(target).unwrap();
+            let ch = grpc_sys::grpc_lame_client_channel_create(
+                target.as_ptr(),
+                RpcStatusCode::INTERNAL.into(),
+                b"call on lame client\0".as_ptr() as _,
+            );
+            Self::new(env.pick_cq(), env, ch)
         }
     }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -98,4 +98,10 @@ impl Client {
         let kicker = self.kicker.clone();
         Executor::new(self.channel.cq()).spawn(f, kicker)
     }
+
+    /// Get the underlying channel.
+    #[inline]
+    pub fn channel(&self) -> &Channel {
+        &self.channel
+    }
 }


### PR DESCRIPTION
We have supported channel state, but it's very inconvenient without the capability of accessing underlying channel of a client. 