### PR TITLE
Provide more debugging info for RpcStatus

### DIFF
--- a/grpc-sys/bindings/bindings.rs
+++ b/grpc-sys/bindings/bindings.rs
@@ -3865,10 +3865,11 @@ pub struct grpcwrap_batch_context__bindgen_ty_2 {
     pub trailing_metadata: grpc_metadata_array,
     pub status: grpc_status_code::Type,
     pub status_details: grpc_slice,
+    pub error_string: *const ::std::os::raw::c_char,
 }
 impl ::std::fmt::Debug for grpcwrap_batch_context__bindgen_ty_2 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write ! (f , "grpcwrap_batch_context__bindgen_ty_2 {{ trailing_metadata: {:?}, status: {:?}, status_details: {:?} }}" , self . trailing_metadata , self . status , self . status_details)
+        write ! (f , "grpcwrap_batch_context__bindgen_ty_2 {{ trailing_metadata: {:?}, status: {:?}, status_details: {:?}, error_string: {:?} }}" , self . trailing_metadata , self . status , self . status_details , self . error_string)
     }
 }
 impl ::std::fmt::Debug for grpcwrap_batch_context {
@@ -4000,6 +4001,11 @@ extern "C" {
     pub fn grpcwrap_batch_context_recv_status_on_client_trailing_metadata(
         ctx: *const grpcwrap_batch_context,
     ) -> *const grpc_metadata_array;
+}
+extern "C" {
+    pub fn grpcwrap_batch_context_recv_status_on_client_error_string(
+        ctx: *const grpcwrap_batch_context,
+    ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
     pub fn grpcwrap_request_call_context_ref_call(

--- a/grpc-sys/grpc_wrap.cc
+++ b/grpc-sys/grpc_wrap.cc
@@ -88,6 +88,7 @@ typedef struct grpcwrap_batch_context {
     grpc_metadata_array trailing_metadata;
     grpc_status_code status;
     grpc_slice status_details;
+    const char* error_string;
   } recv_status_on_client;
   int recv_close_on_server_cancelled;
 } grpcwrap_batch_context;
@@ -260,6 +261,7 @@ grpcwrap_batch_context_destroy(grpcwrap_batch_context* ctx) {
   grpcwrap_metadata_array_destroy_metadata_only(
       &(ctx->recv_status_on_client.trailing_metadata));
   grpc_slice_unref(ctx->recv_status_on_client.status_details);
+  gpr_free((void*)ctx->recv_status_on_client.error_string);
 
   gpr_free(ctx);
 }
@@ -343,6 +345,12 @@ GPR_EXPORT const grpc_metadata_array* GPR_CALLTYPE
 grpcwrap_batch_context_recv_status_on_client_trailing_metadata(
     const grpcwrap_batch_context* ctx) {
   return &(ctx->recv_status_on_client.trailing_metadata);
+}
+
+GPR_EXPORT const char* GPR_CALLTYPE
+grpcwrap_batch_context_recv_status_on_client_error_string(
+    const grpcwrap_batch_context* ctx) {
+  return ctx->recv_status_on_client.error_string;
 }
 
 GPR_EXPORT grpc_call* GPR_CALLTYPE
@@ -518,6 +526,8 @@ GPR_EXPORT grpc_call_error GPR_CALLTYPE grpcwrap_call_start_unary(
       &(ctx->recv_status_on_client.status);
   ops[5].data.recv_status_on_client.status_details =
       &(ctx->recv_status_on_client.status_details);
+  ops[5].data.recv_status_on_client.error_string =
+      &(ctx->recv_status_on_client.error_string);
   ops[5].flags = 0;
   ops[5].reserved = nullptr;
 
@@ -558,6 +568,8 @@ GPR_EXPORT grpc_call_error GPR_CALLTYPE grpcwrap_call_start_client_streaming(
       &(ctx->recv_status_on_client.status);
   ops[3].data.recv_status_on_client.status_details =
       &(ctx->recv_status_on_client.status_details);
+  ops[3].data.recv_status_on_client.error_string =
+      &(ctx->recv_status_on_client.error_string);
   ops[3].flags = 0;
   ops[3].reserved = nullptr;
 
@@ -597,6 +609,8 @@ GPR_EXPORT grpc_call_error GPR_CALLTYPE grpcwrap_call_start_server_streaming(
       &(ctx->recv_status_on_client.status);
   ops[3].data.recv_status_on_client.status_details =
       &(ctx->recv_status_on_client.status_details);
+  ops[3].data.recv_status_on_client.error_string =
+      &(ctx->recv_status_on_client.error_string);
   ops[3].flags = 0;
   ops[3].reserved = nullptr;
 
@@ -626,6 +640,8 @@ GPR_EXPORT grpc_call_error GPR_CALLTYPE grpcwrap_call_start_duplex_streaming(
       &(ctx->recv_status_on_client.status);
   ops[1].data.recv_status_on_client.status_details =
       &(ctx->recv_status_on_client.status_details);
+  ops[1].data.recv_status_on_client.error_string =
+      &(ctx->recv_status_on_client.error_string);
   ops[1].flags = 0;
   ops[1].reserved = nullptr;
 


### PR DESCRIPTION
* grpc-sys: provide error string for receive status on client calls
* call: provide debug error string in RpcStatus
* ~error: make Display ouput more human-readable~
* ~call: make Display of RpcStatusCode more human-readable~

Example of contents of `RpcStatus::debug_error_string`:
```
thread 'test_health_watch_multiple' panicked at 'called `Result::unwrap()` on an `Err` value: RpcFailure(RpcStatus { code: 14-UNAVAILABLE, message: "failed to connect to all addresses", details: [], debug_error_string: "{\"created\":\"@1672417943.726323715\",\"description\":\"Failed to pick subchannel\",\"file\":\"/home/rob/grpc-rs/grpc-sys/grpc/src/core/ext/filters/client_channel/client_channel.cc\",\"file_line\":3217,\"referenced_errors\":[{\"created\":\"@1672417943.726320053\",\"description\":\"failed to connect to all addresses\",\"file\":\"/home/rob/grpc-rs/grpc-sys/grpc/src/core/lib/transport/error_utils.cc\",\"file_line\":165,\"grpc_status\":14}]}" })', health/tests/health_check.rs:137:5
```