### PR TITLE
Publicize prost service generator

### DIFF
--- a/compiler/src/prost_codegen.rs
+++ b/compiler/src/prost_codegen.rs
@@ -74,7 +74,26 @@ where
     Ok(packages)
 }
 
-struct Generator;
+/// [`ServiceGenerator`](prost_build::ServiceGenerator) for generating grpcio services.
+///
+/// Can be used for when there is a need to deviate from the common use case of
+/// [`compile_protos()`]. One can provide a `Generator` instance to
+/// [`prost_build::Config::service_generator()`].
+///
+/// ```rust
+/// use prost_build::Config;
+/// use grpcio_compiler::prost_codegen::Generator;
+///
+///
+/// fn main() -> Result<(), Box<dyn std::error::Error>> {
+///     let mut config = Config::new();
+///     config.service_generator(Box::new(Generator));
+///     // Modify config as needed
+///     config.compile_protos(&["src/frontend.proto", "src/backend.proto"], &["src"])?;
+///     Ok(())
+/// }
+/// ```
+pub struct Generator;
 
 impl ServiceGenerator for Generator {
     fn generate(&mut self, service: Service, buf: &mut String) {


### PR DESCRIPTION
Make the prost service generator available to clients. This allows
clients to customize how the underlying prost build is invoked.

Signed-off-by: Nick Santana <nick@mobilecoin.com>

---
name: Publicize Prost Service Generator
about: Makes the prost generator a public struct

---

**Description of feature:**
The prost service generator is now public, allowing clients finer grain control on the prost build behavior.

**Implementation:**
The initial desire for this was to allow us to build just the services, while re-using the messages.  The current `grpcio_compiler::prost_codegen::compile_protos()` function would either fail to build when local protos were excluded from the include path, or generate the local proto messages to the generated services.
Making the `Generator` public seemed like the best way to meet this current need and also allow future customers to customize the prost build behavior while still generating the grpcio services.

Expanding the availability of the `Generator` looks to be limited to making the `ServiceGenerator` trait methods also available. It doesn't seem to be exposing anything else from the internals.

**Checklist:**

The CI will check all of these, but you'll need to have done them:

* [x] `cargo fmt -- --check` passes.
* [x] `cargo +nightly clippy` has no warnings.
* [x] `cargo test` passes.

