### PR TITLE
Support collecting gRPC core metrics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   pull_request:
   push:
-    branches: 
+    branches:
     - master
     - v0.*
   schedule:
@@ -33,7 +33,7 @@ jobs:
       matrix:
         include:
           - host: ubuntu-latest
-            profile: 
+            profile:
             suffix:
     name: Linux-Stable${{ matrix.suffix }}
     runs-on: ${{ matrix.host }}
@@ -57,7 +57,7 @@ jobs:
       matrix:
         include:
           - host: ubuntu-latest
-            profile: 
+            profile:
             suffix:
     name: Linux-Stable-openssl${{ matrix.suffix }}
     runs-on: ${{ matrix.host }}
@@ -85,7 +85,7 @@ jobs:
     - run: cargo test --all
     # See https://github.com/grpc/grpc/pull/31167
     - run: RUSTFLAGS="-Z sanitizer=address" ASAN_OPTIONS=suppressions=`pwd`/.github/workflows/31167.supp cargo test --all --target x86_64-unknown-linux-gnu
-    - run: cargo test --features "nightly"
+    - run: cargo test --features "nightly stats"
 
   Mac:
     name: Mac
@@ -101,7 +101,7 @@ jobs:
     - run: cargo build --no-default-features --features "prost-codec"
     - run: cargo build
     - run: cargo test --all
-    - run: cargo test --features "nightly"
+    - run: cargo test --features "nightly stats"
 
   Mac-openssl:
     name: Mac-openssl
@@ -124,12 +124,12 @@ jobs:
     - uses: actions/checkout@v2
     - run: choco install -y llvm
     - run: Import-Module $env:ChocolateyInstall\helpers\chocolateyProfile.psm1
-    - run: go version ; cargo version ; cmake --version 
+    - run: go version ; cargo version ; cmake --version
     - run: cargo xtask submodule
     - run: cargo build
     - run: cargo test --all
-    - run: cargo test --features "nightly"
-  
+    - run: cargo test --features "nightly stats"
+
   Pre-Release:
     name: Pre-Release
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ boringssl = ["grpcio-sys/boringssl", "_secure"]
 openssl = ["_secure", "grpcio-sys/openssl"]
 openssl-vendored = ["_secure", "grpcio-sys/openssl-vendored"]
 no-omit-frame-pointer = ["grpcio-sys/no-omit-frame-pointer"]
+stats = ["grpcio-sys/stats"]
 
 [badges]
 travis-ci = { repository = "tikv/grpc-rs" }

--- a/grpc-sys/Cargo.toml
+++ b/grpc-sys/Cargo.toml
@@ -64,8 +64,9 @@ openssl = ["_secure"]
 openssl-vendored = ["openssl", "openssl-sys"]
 no-omit-frame-pointer = []
 # A hidden feature that is used to force regenerating bindings.
-_gen-bindings = ["bindgen"]
+_gen-bindings = ["bindgen", "stats"]
 _list-package = []
+stats = []
 
 [target.'cfg(not(all(any(target_os = "linux", target_os = "macos"), any(target_arch = "x86_64", target_arch = "aarch64"))))'.build-dependencies]
 bindgen = "0.59.0"

--- a/grpc-sys/bindings/bindings_stats.rs
+++ b/grpc-sys/bindings/bindings_stats.rs
@@ -1,0 +1,78 @@
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct grpcwrap_stats {
+    _unused: [u8; 0],
+}
+#[repr(u32)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum grpcwrap_stats_counter {
+    ClientCallsCreated = 0,
+    ServerCallsCreated = 1,
+    ClientChannelsCreated = 2,
+    ClientSubchannelsCreated = 3,
+    ServerChannelsCreated = 4,
+    InsecureConnectionsCreated = 5,
+    SyscallWrite = 6,
+    SyscallRead = 7,
+    TcpReadAlloc8k = 8,
+    TcpReadAlloc64k = 9,
+    Http2SettingsWrites = 10,
+    Http2PingsSent = 11,
+    Http2WritesBegun = 12,
+    Http2TransportStalls = 13,
+    Http2StreamStalls = 14,
+    CqPluckCreates = 15,
+    CqNextCreates = 16,
+    CqCallbackCreates = 17,
+    COUNTER_COUNT = 18,
+}
+#[repr(u32)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum grpcwrap_stats_histogram {
+    CallInitialSize = 0,
+    TcpWriteSize = 1,
+    TcpWriteIovSize = 2,
+    TcpReadSize = 3,
+    TcpReadOffer = 4,
+    TcpReadOfferIovSize = 5,
+    Http2SendMessageSize = 6,
+    Http2MetadataSize = 7,
+    HISTOGRAM_COUNT = 8,
+}
+extern "C" {
+    pub fn grpcwrap_stats_collect() -> *mut grpcwrap_stats;
+}
+extern "C" {
+    pub fn grpcwrap_stats_free(stats: *mut grpcwrap_stats);
+}
+extern "C" {
+    pub fn grpcwrap_stats_get_counter(
+        stats: *const grpcwrap_stats,
+        which: grpcwrap_stats_counter,
+    ) -> u64;
+}
+extern "C" {
+    pub fn grpcwrap_stats_counter_name(which: grpcwrap_stats_counter) -> grpc_slice;
+}
+extern "C" {
+    pub fn grpcwrap_stats_counter_doc(which: grpcwrap_stats_counter) -> grpc_slice;
+}
+extern "C" {
+    pub fn grpcwrap_stats_get_histogram_percentile(
+        stats: *const grpcwrap_stats,
+        which: grpcwrap_stats_histogram,
+        percentile: f64,
+    ) -> f64;
+}
+extern "C" {
+    pub fn grpcwrap_stats_get_histogram_count(
+        stats: *const grpcwrap_stats,
+        which: grpcwrap_stats_histogram,
+    ) -> u64;
+}
+extern "C" {
+    pub fn grpcwrap_stats_histogram_name(which: grpcwrap_stats_histogram) -> grpc_slice;
+}
+extern "C" {
+    pub fn grpcwrap_stats_histogram_doc(which: grpcwrap_stats_histogram) -> grpc_slice;
+}

--- a/grpc-sys/grpc_wrap_stats.cc
+++ b/grpc-sys/grpc_wrap_stats.cc
@@ -1,0 +1,132 @@
+// Copyright 2023 TiKV Project Authors. Licensed under Apache-2.0.
+
+// #ifdef GRPC_SYS_METRICS
+// #endif
+
+#include <src/core/lib/debug/stats.h>
+#include <src/core/lib/debug/stats_data.h>
+#include <grpc/support/log.h>
+
+#ifdef GPR_WINDOWS
+#define GPR_EXPORT extern "C" __declspec(dllexport)
+#define GPR_CALLTYPE __cdecl
+#endif
+
+#ifndef GPR_EXPORT
+#define GPR_EXPORT extern "C"
+#endif
+
+#ifndef GPR_CALLTYPE
+#define GPR_CALLTYPE
+#endif
+
+/** gRPC stats.
+    See: grpc/src/core/lib/debug/stats_data.yaml */
+typedef struct grpcwrap_stats grpcwrap_stats;
+
+enum grpcwrap_stats_counter {
+  ClientCallsCreated,
+  ServerCallsCreated,
+  ClientChannelsCreated,
+  ClientSubchannelsCreated,
+  ServerChannelsCreated,
+  InsecureConnectionsCreated,
+  SyscallWrite,
+  SyscallRead,
+  TcpReadAlloc8k,
+  TcpReadAlloc64k,
+  Http2SettingsWrites,
+  Http2PingsSent,
+  Http2WritesBegun,
+  Http2TransportStalls,
+  Http2StreamStalls,
+  CqPluckCreates,
+  CqNextCreates,
+  CqCallbackCreates,
+  COUNTER_COUNT
+};
+// Just make sure they have the same number of counters.
+static_assert((int)grpcwrap_stats_counter::COUNTER_COUNT ==
+              (int)grpc_core::GlobalStats::Counter::COUNT);
+
+enum grpcwrap_stats_histogram {
+  CallInitialSize,
+  TcpWriteSize,
+  TcpWriteIovSize,
+  TcpReadSize,
+  TcpReadOffer,
+  TcpReadOfferIovSize,
+  Http2SendMessageSize,
+  Http2MetadataSize,
+  HISTOGRAM_COUNT
+};
+// Just make sure they have the same number of histograms.
+static_assert((int)grpcwrap_stats_histogram::HISTOGRAM_COUNT ==
+              (int)grpc_core::GlobalStats::Histogram::COUNT);
+
+GPR_EXPORT grpcwrap_stats* GPR_CALLTYPE grpcwrap_stats_collect() {
+  return (grpcwrap_stats*)grpc_core::global_stats().Collect().release();
+}
+
+GPR_EXPORT void GPR_CALLTYPE grpcwrap_stats_free(grpcwrap_stats* stats) {
+  auto s = (grpc_core::GlobalStats*)stats;
+  delete s;
+}
+
+GPR_EXPORT uint64_t GPR_CALLTYPE grpcwrap_stats_get_counter(
+    const grpcwrap_stats* stats, grpcwrap_stats_counter which) {
+  GPR_ASSERT(which < static_cast<int>(grpc_core::GlobalStats::Counter::COUNT));
+  auto s = (const grpc_core::GlobalStats*)stats;
+  return s->counters[which];
+}
+
+GPR_EXPORT grpc_slice GPR_CALLTYPE
+grpcwrap_stats_counter_name(grpcwrap_stats_counter which) {
+  GPR_ASSERT(which < static_cast<int>(grpc_core::GlobalStats::Counter::COUNT));
+  auto name = grpc_core::GlobalStats::counter_name[which];
+  auto slice = grpc_slice_from_static_buffer(name.data(), name.length());
+  return slice;
+}
+
+GPR_EXPORT grpc_slice GPR_CALLTYPE
+grpcwrap_stats_counter_doc(grpcwrap_stats_counter which) {
+  GPR_ASSERT(which < static_cast<int>(grpc_core::GlobalStats::Counter::COUNT));
+  auto doc = grpc_core::GlobalStats::counter_doc[which];
+  auto slice = grpc_slice_from_static_buffer(doc.data(), doc.length());
+  return slice;
+}
+
+GPR_EXPORT double GPR_CALLTYPE grpcwrap_stats_get_histogram_percentile(
+    const grpcwrap_stats* stats, grpcwrap_stats_histogram which,
+    double percentile) {
+  GPR_ASSERT(which < static_cast<int>(grpc_core::GlobalStats::Counter::COUNT));
+  auto s = (const grpc_core::GlobalStats*)stats;
+  return s->histogram(static_cast<grpc_core::GlobalStats::Histogram>(which))
+      .Percentile(percentile);
+}
+
+GPR_EXPORT uint64_t GPR_CALLTYPE grpcwrap_stats_get_histogram_count(
+    const grpcwrap_stats* stats, grpcwrap_stats_histogram which) {
+  GPR_ASSERT(which < static_cast<int>(grpc_core::GlobalStats::Counter::COUNT));
+  auto s = (const grpc_core::GlobalStats*)stats;
+  return s->histogram(static_cast<grpc_core::GlobalStats::Histogram>(which))
+      .Count();
+}
+
+GPR_EXPORT grpc_slice GPR_CALLTYPE
+grpcwrap_stats_histogram_name(grpcwrap_stats_histogram which) {
+  GPR_ASSERT(which <
+             static_cast<int>(grpc_core::GlobalStats::Histogram::COUNT));
+  auto name = grpc_core::GlobalStats::histogram_name[which];
+  auto slice = grpc_slice_from_static_buffer(name.data(), name.length());
+  return slice;
+}
+
+GPR_EXPORT grpc_slice GPR_CALLTYPE
+grpcwrap_stats_histogram_doc(grpcwrap_stats_histogram which) {
+  GPR_ASSERT(which <
+             static_cast<int>(grpc_core::GlobalStats::Histogram::COUNT));
+  auto doc = grpc_core::GlobalStats::histogram_doc[which];
+  auto slice = grpc_slice_from_static_buffer(doc.data(), doc.length());
+  return slice;
+}

--- a/grpc-sys/grpc_wrap_stats.cc
+++ b/grpc-sys/grpc_wrap_stats.cc
@@ -46,8 +46,8 @@ enum grpcwrap_stats_counter {
   COUNTER_COUNT
 };
 // Just make sure they have the same number of counters.
-static_assert((int)grpcwrap_stats_counter::COUNTER_COUNT ==
-              (int)grpc_core::GlobalStats::Counter::COUNT);
+static_assert(static_cast<int>(grpcwrap_stats_counter::COUNTER_COUNT) ==
+              static_cast<int>(grpc_core::GlobalStats::Counter::COUNT));
 
 enum grpcwrap_stats_histogram {
   CallInitialSize,
@@ -61,8 +61,8 @@ enum grpcwrap_stats_histogram {
   HISTOGRAM_COUNT
 };
 // Just make sure they have the same number of histograms.
-static_assert((int)grpcwrap_stats_histogram::HISTOGRAM_COUNT ==
-              (int)grpc_core::GlobalStats::Histogram::COUNT);
+static_assert(static_cast<int>(grpcwrap_stats_histogram::HISTOGRAM_COUNT) ==
+              static_cast<int>(grpc_core::GlobalStats::Histogram::COUNT));
 
 GPR_EXPORT grpcwrap_stats* GPR_CALLTYPE grpcwrap_stats_collect() {
   return (grpcwrap_stats*)grpc_core::global_stats().Collect().release();

--- a/grpc-sys/src/lib.rs
+++ b/grpc-sys/src/lib.rs
@@ -5,7 +5,9 @@
 #![allow(non_upper_case_globals)]
 #[allow(clippy::all)]
 mod bindings {
-    include!(env!("BINDING_PATH"));
+    include!(env!("BINDING_WRAP_PATH"));
+    #[cfg(feature = "stats")]
+    include!(env!("BINDING_WRAP_STATS_PATH"));
 }
 mod grpc_wrap;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,6 +43,8 @@ mod metadata;
 mod quota;
 mod security;
 mod server;
+#[cfg(feature = "stats")]
+pub mod stats;
 mod task;
 
 pub use crate::buf::GrpcSlice;

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -17,22 +17,26 @@ unsafe fn slice_to_string(slice: grpc_slice) -> String {
 
 macro_rules! stats_item {
     (
+        $(#[$item_attr:meta])*
         $item:ident($inner:ident);
         $name_func:ident;
         $doc_func:ident;
         $(
-            ($num:path, $konst:ident);
+            $(#[$konst_attr:meta])* ($num:path, $konst:ident);
         )+
     ) => {
-        #[derive(PartialEq, Eq, Clone, Copy)]
+        $(#[$item_attr])*
         pub struct $item($inner);
 
         impl $item {
         $(
+            $(#[$konst_attr])*
             pub const $konst: $item = $item($num);
         )+
+            /// All kinds of this stat.
             pub const ALL: &[$item] = &[ $( $item::$konst, )+ ];
 
+            // Returns name of this stat.
             pub fn name(&self) -> String {
                 unsafe {
                     let slice = $name_func(self.0);
@@ -40,6 +44,7 @@ macro_rules! stats_item {
                 }
             }
 
+            // Returns doc of this stat.
             pub fn doc(&self) -> String {
                 unsafe {
                     let slice = $doc_func(self.0);
@@ -64,40 +69,70 @@ macro_rules! stats_item {
 }
 
 stats_item! {
+    /// gRPC stats counter.
+    #[derive(PartialEq, Eq, Clone, Copy)]
     Counter(grpcwrap_stats_counter);
     grpcwrap_stats_counter_name;
     grpcwrap_stats_counter_doc;
+    /// Number of client side calls created by this process
     (grpcwrap_stats_counter::ClientCallsCreated, CLIENT_CALLS_CREATED);
+    /// Number of server side calls created by this process
     (grpcwrap_stats_counter::ServerCallsCreated, SERVER_CALLS_CREATED);
+    /// Number of client channels created
     (grpcwrap_stats_counter::ClientChannelsCreated, CLIENT_CHANNELS_CREATED);
+    /// Number of client subchannels created
     (grpcwrap_stats_counter::ClientSubchannelsCreated, CLIENT_SUBCHANNELS_CREATED);
+    /// Number of server channels created
     (grpcwrap_stats_counter::ServerChannelsCreated, SERVER_CHANNELS_CREATED);
+    /// Number of insecure connections created
     (grpcwrap_stats_counter::InsecureConnectionsCreated, INSECURE_CONNECTIONS_CREATED);
+    /// Number of write syscalls (or equivalent - eg sendmsg) made by this process
     (grpcwrap_stats_counter::SyscallWrite, SYSCALL_WRITE);
+    /// Number of read syscalls (or equivalent - eg recvmsg) made by this process
     (grpcwrap_stats_counter::SyscallRead, SYSCALL_READ);
+    /// Number of 8k allocations by the TCP subsystem for reading
     (grpcwrap_stats_counter::TcpReadAlloc8k, TCP_READ_ALLOC_8K);
+    /// Number of 64k allocations by the TCP subsystem for reading
     (grpcwrap_stats_counter::TcpReadAlloc64k, TCP_READ_ALLOC_64K);
+    /// Number of settings frames sent
     (grpcwrap_stats_counter::Http2SettingsWrites, HTTP2_SETTINGS_WRITES);
+    /// Number of HTTP2 pings sent by process
     (grpcwrap_stats_counter::Http2PingsSent, HTTP_2PINGS_SENT);
+    /// Number of HTTP2 writes initiated
     (grpcwrap_stats_counter::Http2WritesBegun, HTTP2_WRITES_BEGUN);
+    /// Number of times sending was completely stalled by the transport flow control window
     (grpcwrap_stats_counter::Http2TransportStalls, HTTP2_TRANSPORT_STALLS);
+    /// Number of times sending was completely stalled by the stream flow control window
     (grpcwrap_stats_counter::Http2StreamStalls, HTTP2_STREAM_STALLS);
+    /// Number of completion queues created for cq_pluck (indicates sync api usage)
     (grpcwrap_stats_counter::CqPluckCreates, CQ_PLUCK_CREATES);
+    /// Number of completion queues created for cq_next (indicates cq async api usage)
     (grpcwrap_stats_counter::CqNextCreates, CQ_NEXT_CREATES);
+    /// Number of completion queues created for cq_callback (indicates callback api usage)
     (grpcwrap_stats_counter::CqCallbackCreates, CQ_CALLBACK_CREATES);
 }
 
 stats_item! {
+    /// gRPC stats histogram.
+    #[derive(PartialEq, Eq, Clone, Copy)]
     Histogram(grpcwrap_stats_histogram);
     grpcwrap_stats_histogram_name;
     grpcwrap_stats_histogram_doc;
+    /// Initial size of the grpc_call arena created at call start
     (grpcwrap_stats_histogram::CallInitialSize, CALL_INITIAL_SIZE);
+    /// Number of bytes offered to each syscall_write
     (grpcwrap_stats_histogram::TcpWriteSize, TCP_WRITE_SIZE);
+    /// Number of byte segments offered to each syscall_write
     (grpcwrap_stats_histogram::TcpWriteIovSize, TCP_WRITE_IOV_SIZE);
+    /// Number of bytes received by each syscall_read
     (grpcwrap_stats_histogram::TcpReadSize, TCP_READ_SIZE);
+    /// Number of bytes offered to each syscall_read
     (grpcwrap_stats_histogram::TcpReadOffer, TCP_READ_OFFER);
+    /// Number of byte segments offered to each syscall_read
     (grpcwrap_stats_histogram::TcpReadOfferIovSize, TCP_READ_OFFER_IOV_SIZE);
+    /// Size of messages received by HTTP2 transport
     (grpcwrap_stats_histogram::Http2SendMessageSize, HTTP2_SEND_MESSAGE_SIZE);
+    /// Number of bytes consumed by metadata, according to HPACK accounting rules
     (grpcwrap_stats_histogram::Http2MetadataSize, HTTP2_METADATA_SIZE);
 }
 

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -1,0 +1,167 @@
+// Copyright 2023 TiKV Project Authors. Licensed under Apache-2.0.
+
+use std::{
+    fmt::{self, Debug, Display},
+    slice, str,
+};
+
+use grpcio_sys::*;
+
+unsafe fn slice_to_string(slice: grpc_slice) -> String {
+    let mut len = 0;
+    let ptr = grpcwrap_slice_raw_offset(&slice, 0, &mut len);
+    let string = str::from_utf8_unchecked(slice::from_raw_parts(ptr as _, len)).to_owned();
+    grpc_slice_unref(slice);
+    string
+}
+
+macro_rules! stats_item {
+    (
+        $item:ident($inner:ident);
+        $name_func:ident;
+        $doc_func:ident;
+        $(
+            ($num:path, $konst:ident);
+        )+
+    ) => {
+        #[derive(PartialEq, Eq, Clone, Copy)]
+        pub struct $item($inner);
+
+        impl $item {
+        $(
+            pub const $konst: $item = $item($num);
+        )+
+            pub const ALL: &[$item] = &[ $( $item::$konst, )+ ];
+
+            pub fn name(&self) -> String {
+                unsafe {
+                    let slice = $name_func(self.0);
+                    slice_to_string(slice)
+                }
+            }
+
+            pub fn doc(&self) -> String {
+                unsafe {
+                    let slice = $doc_func(self.0);
+                    slice_to_string(slice)
+                }
+            }
+        }
+
+        impl Display for $item {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+                Debug::fmt(self, f)
+            }
+        }
+
+        impl Debug for $item {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+                write!(f, "{}", self.name(),
+                )
+            }
+        }
+    }
+}
+
+stats_item! {
+    Counter(grpcwrap_stats_counter);
+    grpcwrap_stats_counter_name;
+    grpcwrap_stats_counter_doc;
+    (grpcwrap_stats_counter::ClientCallsCreated, CLIENT_CALLS_CREATED);
+    (grpcwrap_stats_counter::ServerCallsCreated, SERVER_CALLS_CREATED);
+    (grpcwrap_stats_counter::ClientChannelsCreated, CLIENT_CHANNELS_CREATED);
+    (grpcwrap_stats_counter::ClientSubchannelsCreated, CLIENT_SUBCHANNELS_CREATED);
+    (grpcwrap_stats_counter::ServerChannelsCreated, SERVER_CHANNELS_CREATED);
+    (grpcwrap_stats_counter::InsecureConnectionsCreated, INSECURE_CONNECTIONS_CREATED);
+    (grpcwrap_stats_counter::SyscallWrite, SYSCALL_WRITE);
+    (grpcwrap_stats_counter::SyscallRead, SYSCALL_READ);
+    (grpcwrap_stats_counter::TcpReadAlloc8k, TCP_READ_ALLOC_8K);
+    (grpcwrap_stats_counter::TcpReadAlloc64k, TCP_READ_ALLOC_64K);
+    (grpcwrap_stats_counter::Http2SettingsWrites, HTTP2_SETTINGS_WRITES);
+    (grpcwrap_stats_counter::Http2PingsSent, HTTP_2PINGS_SENT);
+    (grpcwrap_stats_counter::Http2WritesBegun, HTTP2_WRITES_BEGUN);
+    (grpcwrap_stats_counter::Http2TransportStalls, HTTP2_TRANSPORT_STALLS);
+    (grpcwrap_stats_counter::Http2StreamStalls, HTTP2_STREAM_STALLS);
+    (grpcwrap_stats_counter::CqPluckCreates, CQ_PLUCK_CREATES);
+    (grpcwrap_stats_counter::CqNextCreates, CQ_NEXT_CREATES);
+    (grpcwrap_stats_counter::CqCallbackCreates, CQ_CALLBACK_CREATES);
+}
+
+stats_item! {
+    Histogram(grpcwrap_stats_histogram);
+    grpcwrap_stats_histogram_name;
+    grpcwrap_stats_histogram_doc;
+    (grpcwrap_stats_histogram::CallInitialSize, CALL_INITIAL_SIZE);
+    (grpcwrap_stats_histogram::TcpWriteSize, TCP_WRITE_SIZE);
+    (grpcwrap_stats_histogram::TcpWriteIovSize, TCP_WRITE_IOV_SIZE);
+    (grpcwrap_stats_histogram::TcpReadSize, TCP_READ_SIZE);
+    (grpcwrap_stats_histogram::TcpReadOffer, TCP_READ_OFFER);
+    (grpcwrap_stats_histogram::TcpReadOfferIovSize, TCP_READ_OFFER_IOV_SIZE);
+    (grpcwrap_stats_histogram::Http2SendMessageSize, HTTP2_SEND_MESSAGE_SIZE);
+    (grpcwrap_stats_histogram::Http2MetadataSize, HTTP2_METADATA_SIZE);
+}
+
+pub struct Stats {
+    stats: *mut grpcwrap_stats,
+}
+
+impl Drop for Stats {
+    fn drop(&mut self) {
+        unsafe {
+            grpcwrap_stats_free(self.stats);
+        }
+    }
+}
+
+impl Stats {
+    pub fn collect() -> Stats {
+        let stats = unsafe { grpcwrap_stats_collect() };
+        Stats { stats }
+    }
+
+    pub fn counter(&self, which: Counter) -> u64 {
+        unsafe { grpcwrap_stats_get_counter(self.stats, which.0) }
+    }
+
+    pub fn histogram_percentile(&self, which: Histogram, percentile: f64) -> f64 {
+        unsafe { grpcwrap_stats_get_histogram_percentile(self.stats, which.0, percentile) }
+    }
+
+    pub fn histogram_count(&self, which: Histogram) -> u64 {
+        unsafe { grpcwrap_stats_get_histogram_count(self.stats, which.0) }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_name_doc() {
+        for i in Counter::ALL {
+            let _ = i.name();
+            let _ = i.doc();
+        }
+        for i in Histogram::ALL {
+            let _ = i.name();
+            let _ = i.doc();
+        }
+    }
+
+    #[test]
+    fn test_counter() {
+        let stats = Stats::collect();
+        for i in Counter::ALL {
+            let _ = stats.counter(*i);
+        }
+    }
+
+    #[test]
+    fn test_histogram() {
+        let stats = Stats::collect();
+        for i in Histogram::ALL {
+            let _ = stats.histogram_count(*i);
+            let _ = stats.histogram_percentile(*i, 0.99);
+        }
+    }
+}

--- a/tests-and-examples/Cargo.toml
+++ b/tests-and-examples/Cargo.toml
@@ -21,7 +21,7 @@ protobuf = { version = "2.22", optional = true }
 prost = { version = "0.11", optional = true }
 bytes = { version = "1.0", optional = true }
 log = "0.4"
-grpcio = { path = "..", default-features = false, features = ["boringssl"] }
+grpcio = { path = "..", default-features = false, features = ["boringssl", "stats"] }
 grpcio-health = { path = "../health", default-features = false }
 
 [dev-dependencies]

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -98,15 +98,21 @@ fn submodule() {
 }
 
 fn clang_lint() {
-    exec(cmd("clang-tidy").args(&[
-        "grpc-sys/grpc_wrap.cc",
-        "--",
-        "-Igrpc-sys/grpc/include",
-        "-x",
-        "c++",
-        "-std=c++11",
-    ]));
-    exec(cmd("clang-format").args(&["-i", "grpc-sys/grpc_wrap.cc"]));
+    fn lint(file: &str) {
+        exec(cmd("clang-tidy").args(&[
+            file,
+            "--",
+            "-Igrpc-sys/grpc/include",
+            "-Igrpc-sys/grpc",
+            "-Igrpc-sys/grpc/third_party/abseil-cpp",
+            "-x",
+            "c++",
+            "-std=c++14",
+        ]));
+        exec(cmd("clang-format").args(&["-i", file]));
+    }
+    lint("grpc-sys/grpc_wrap.cc");
+    lint("grpc-sys/grpc_wrap_stats.cc");
 }
 
 const PROTOS: &[(&str, &[&str], &str, &str)] = &[


### PR DESCRIPTION
Collect gRPC core metrics:

* Counters:
    * client_calls_created
    * server_calls_created
    * client_channels_created
    * client_subchannels_created
    * server_channels_created
    * insecure_connections_created
    * syscall_write
    * syscall_read
    * tcp_read_alloc_8k
    * tcp_read_alloc_64k
    * http2_settings_writes
    * http2_pings_sent
    * http2_writes_begun
    * http2_transport_stalls
    * http2_stream_stalls
    * cq_pluck_creates
    * cq_next_creates
    * cq_callback_creates
* Histograms
    * call_initial_size
    * tcp_write_size
    * tcp_write_iov_size
    * tcp_read_size
    * tcp_read_offer
    * tcp_read_offer_iov_size
    * http2_send_message_size
    * http2_metadata_size

Details: https://github.com/grpc/grpc/blob/v1.56.0/src/core/lib/debug/stats_data.yaml

This PR add a new cc file called `grpc_wrap_stats.cc` and generates bindings 
into a new file called `binding_stats.rs`.
Collecting metrics needs to include headers under in `grpc/src/`.
I think it's better to be an optional feature and codes are in separated files.
