### PR TITLE
remove uses_cxx11 call in build_grpc causing macos build failure

### DIFF
--- a/cross_compile.md
+++ b/cross_compile.md
@@ -32,9 +32,7 @@ yum install mingw64-openssl-static mingw64-zlib-static mingw64-winpthreads-stati
             .define("CMAKE_SYSTEM_PROCESSOR", get_env("CARGO_CFG_TARGET_ARCH").unwrap())
             .define("CMAKE_CROSSCOMPILING", "true")
             .build_target(library)
-            .uses_cxx11()
             .build()
-        // config.build_target(library).uses_cxx11().build()
     };
 ```
 

--- a/src/call/client.rs
+++ b/src/call/client.rs
@@ -437,7 +437,7 @@ impl<Req> StreamingCallSink<Req> {
     /// The rules are listed as below:
     /// - All messages except the last one will be sent with `buffer_hint` set to true.
     /// - The last message will also be sent with `buffer_hint` set to true unless any message is
-    ///    offered with buffer hint set to false.
+    ///  offered with buffer hint set to false.
     ///
     /// No matter `enhance_batch` is true or false, it's recommended to follow the contract of
     /// Sink and call `poll_flush` to ensure messages are handled by gRPC C Core.

--- a/src/call/client.rs
+++ b/src/call/client.rs
@@ -437,7 +437,7 @@ impl<Req> StreamingCallSink<Req> {
     /// The rules are listed as below:
     /// - All messages except the last one will be sent with `buffer_hint` set to true.
     /// - The last message will also be sent with `buffer_hint` set to true unless any message is
-    ///   offered with buffer hint set to false.
+    ///  offered with buffer hint set to false.
     ///
     /// No matter `enhance_batch` is true or false, it's recommended to follow the contract of
     /// Sink and call `poll_flush` to ensure messages are handled by gRPC C Core.

--- a/src/call/client.rs
+++ b/src/call/client.rs
@@ -436,8 +436,7 @@ impl<Req> StreamingCallSink<Req> {
     /// `enhance_batch` is enabled, messages will be batched together as many as possible.
     /// The rules are listed as below:
     /// - All messages except the last one will be sent with `buffer_hint` set to true.
-    /// - The last message will also be sent with `buffer_hint` set to true unless any message is
-    ///  offered with buffer hint set to false.
+    /// - The last message will also be sent with `buffer_hint` set to true unless any message is offered with buffer hint set to false.
     ///
     /// No matter `enhance_batch` is true or false, it's recommended to follow the contract of
     /// Sink and call `poll_flush` to ensure messages are handled by gRPC C Core.

--- a/src/call/client.rs
+++ b/src/call/client.rs
@@ -437,7 +437,7 @@ impl<Req> StreamingCallSink<Req> {
     /// The rules are listed as below:
     /// - All messages except the last one will be sent with `buffer_hint` set to true.
     /// - The last message will also be sent with `buffer_hint` set to true unless any message is
-    ///  offered with buffer hint set to false.
+    ///    offered with buffer hint set to false.
     ///
     /// No matter `enhance_batch` is true or false, it's recommended to follow the contract of
     /// Sink and call `poll_flush` to ensure messages are handled by gRPC C Core.

--- a/src/call/server.rs
+++ b/src/call/server.rs
@@ -482,7 +482,7 @@ macro_rules! impl_stream_sink {
             /// The rules are listed as below:
             /// - All messages except the last one will be sent with `buffer_hint` set to true.
             /// - The last message will also be sent with `buffer_hint` set to true unless any message is
-            ///   offered with buffer hint set to false.
+            ///  offered with buffer hint set to false.
             ///
             /// No matter `enhance_batch` is true or false, it's recommended to follow the contract of
             /// Sink and call `poll_flush` to ensure messages are handled by gRPC C Core.
@@ -617,24 +617,24 @@ macro_rules! impl_stream_sink {
 }
 
 impl_stream_sink!(
-    /// A sink for server streaming call.
-    ///
-    /// To close the sink properly, you should call [`close`] or [`fail`] before dropping.
-    ///
-    /// [`close`]: #method.close
-    /// [`fail`]: #method.fail
+/// A sink for server streaming call.
+///
+/// To close the sink properly, you should call [`close`] or [`fail`] before dropping.
+///
+/// [`close`]: #method.close
+/// [`fail`]: #method.fail
     #[must_use = "if unused the sink may immediately cancel the RPC"]
     ServerStreamingSink,
     ServerStreamingSinkFailure,
     ShareCall
 );
 impl_stream_sink!(
-    /// A sink for duplex streaming call.
-    ///
-    /// To close the sink properly, you should call [`close`] or [`fail`] before dropping.
-    ///
-    /// [`close`]: #method.close
-    /// [`fail`]: #method.fail
+/// A sink for duplex streaming call.
+///
+/// To close the sink properly, you should call [`close`] or [`fail`] before dropping.
+///
+/// [`close`]: #method.close
+/// [`fail`]: #method.fail
     #[must_use = "if unused the sink may immediately cancel the RPC"]
     DuplexSink,
     DuplexSinkFailure,

--- a/src/call/server.rs
+++ b/src/call/server.rs
@@ -481,8 +481,7 @@ macro_rules! impl_stream_sink {
             /// `enhance_batch` is enabled, messages will be batched together as many as possible.
             /// The rules are listed as below:
             /// - All messages except the last one will be sent with `buffer_hint` set to true.
-            /// - The last message will also be sent with `buffer_hint` set to true unless any message is
-            ///  offered with buffer hint set to false.
+            /// - The last message will also be sent with `buffer_hint` set to true unless any message is offered with buffer hint set to false.
             ///
             /// No matter `enhance_batch` is true or false, it's recommended to follow the contract of
             /// Sink and call `poll_flush` to ensure messages are handled by gRPC C Core.

--- a/src/call/server.rs
+++ b/src/call/server.rs
@@ -482,7 +482,7 @@ macro_rules! impl_stream_sink {
             /// The rules are listed as below:
             /// - All messages except the last one will be sent with `buffer_hint` set to true.
             /// - The last message will also be sent with `buffer_hint` set to true unless any message is
-            ///  offered with buffer hint set to false.
+            ///    offered with buffer hint set to false.
             ///
             /// No matter `enhance_batch` is true or false, it's recommended to follow the contract of
             /// Sink and call `poll_flush` to ensure messages are handled by gRPC C Core.

--- a/src/call/server.rs
+++ b/src/call/server.rs
@@ -482,7 +482,7 @@ macro_rules! impl_stream_sink {
             /// The rules are listed as below:
             /// - All messages except the last one will be sent with `buffer_hint` set to true.
             /// - The last message will also be sent with `buffer_hint` set to true unless any message is
-            ///    offered with buffer hint set to false.
+            ///  offered with buffer hint set to false.
             ///
             /// No matter `enhance_batch` is true or false, it's recommended to follow the contract of
             /// Sink and call `poll_flush` to ensure messages are handled by gRPC C Core.
@@ -617,24 +617,24 @@ macro_rules! impl_stream_sink {
 }
 
 impl_stream_sink!(
-/// A sink for server streaming call.
-///
-/// To close the sink properly, you should call [`close`] or [`fail`] before dropping.
-///
-/// [`close`]: #method.close
-/// [`fail`]: #method.fail
+    /// A sink for server streaming call.
+    ///
+    /// To close the sink properly, you should call [`close`] or [`fail`] before dropping.
+    ///
+    /// [`close`]: #method.close
+    /// [`fail`]: #method.fail
     #[must_use = "if unused the sink may immediately cancel the RPC"]
     ServerStreamingSink,
     ServerStreamingSinkFailure,
     ShareCall
 );
 impl_stream_sink!(
-/// A sink for duplex streaming call.
-///
-/// To close the sink properly, you should call [`close`] or [`fail`] before dropping.
-///
-/// [`close`]: #method.close
-/// [`fail`]: #method.fail
+    /// A sink for duplex streaming call.
+    ///
+    /// To close the sink properly, you should call [`close`] or [`fail`] before dropping.
+    ///
+    /// [`close`]: #method.close
+    /// [`fail`]: #method.fail
     #[must_use = "if unused the sink may immediately cancel the RPC"]
     DuplexSink,
     DuplexSinkFailure,

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -143,18 +143,18 @@ impl Clone for MetadataBuilder {
 ///
 /// - Request headers
 ///
-///     They are sent by the client at the beginning of a remote call before
-///   any request messages are sent.
+///  They are sent by the client at the beginning of a remote call before
+///  any request messages are sent.
 ///
 /// - Response headers
 ///
-///     They are sent by the server at the beginning of a remote call handler
-///   before any response messages are sent.
+///  They are sent by the server at the beginning of a remote call handler
+///  before any response messages are sent.
 ///
 /// - Response trailers
 ///
-///     They are sent by the server at the end of a remote call along with
-///   resulting call status.
+///  They are sent by the server at the end of a remote call along with
+///  resulting call status.
 ///
 /// Metadata value can be ascii string or bytes. They are distinguish by the
 /// key suffix, key of bytes value should have suffix '-bin'.


### PR DESCRIPTION
Resolution of MacOS build issue I outlined in https://github.com/tikv/grpc-rs/issues/654 and related context to cc-rs and cmake. I'd suggested removing `uses_cx11`, which was confusingly appending to the system output of OS value and also removing the example from the documentation comment and example in [cross_compile.md](https://github.com/tikv/grpc-rs/blob/master/cross_compile.md) under All diff in fn build_grpc