### PR TITLE
659 gpr assert absl check

### DIFF
--- a/grpc-sys/build.rs
+++ b/grpc-sys/build.rs
@@ -443,7 +443,7 @@ fn bindgen_grpc(file_path: &Path) {
         .header("grpc_wrap.cc")
         .clang_arg("-xc++")
         .clang_arg("-I./grpc/include")
-        .clang_arg("-std=c++11")
+        .clang_arg("-std=c++14")
         .impl_debug(true)
         .size_t_is_usize(true)
         .disable_header_comment()
@@ -558,7 +558,7 @@ fn main() {
 
     cc.cpp(true);
     if !cfg!(target_env = "msvc") {
-        cc.flag("-std=c++11");
+        cc.flag("-std=c++14");
     }
     cc.file("grpc_wrap.cc");
     cc.warnings_into_errors(true);

--- a/grpc-sys/grpc_wrap.cc
+++ b/grpc-sys/grpc_wrap.cc
@@ -66,6 +66,11 @@
 #define GPR_CALLTYPE
 #endif
 
+#ifndef GPR_ASSERT
+#include <assert.h>
+#define GPR_ASSERT assert
+#endif
+
 grpc_byte_buffer* string_to_byte_buffer(const char* buffer, size_t len) {
   grpc_slice slice = grpc_slice_from_copied_buffer(buffer, len);
   grpc_byte_buffer* bb = grpc_raw_byte_buffer_create(&slice, 1);

--- a/grpc-sys/grpc_wrap.cc
+++ b/grpc-sys/grpc_wrap.cc
@@ -67,8 +67,9 @@
 #endif
 
 #ifndef GPR_ASSERT
-#include <assert.h>
-#define GPR_ASSERT assert
+#include <string_view>
+#include <absl/log/absl_check.h>
+#define GPR_ASSERT ABSL_CHECK
 #endif
 
 grpc_byte_buffer* string_to_byte_buffer(const char* buffer, size_t len) {

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -105,7 +105,7 @@ fn clang_lint() {
         "-Igrpc-sys/grpc/include",
         "-x",
         "c++",
-        "-std=c++11",
+        "-std=c++14",
     ]));
     exec(cmd("clang-format").args(&["-i", "grpc-sys/grpc_wrap.cc"]));
 }


### PR DESCRIPTION
```
% cargo build
   Compiling grpcio-sys v0.13.0+1.56.2-patched (/home/nkurtov/code/grpc-rs/grpc-sys)
warning: grpcio-sys@0.13.0+1.56.2-patched: In file included from /usr/include/absl/log/internal/nullstream.h:37,
warning: grpcio-sys@0.13.0+1.56.2-patched:                  from /usr/include/absl/log/internal/check_op.h:40,
warning: grpcio-sys@0.13.0+1.56.2-patched:                  from /usr/include/absl/log/internal/check_impl.h:19,
warning: grpcio-sys@0.13.0+1.56.2-patched:                  from /usr/include/absl/log/absl_check.h:38,
warning: grpcio-sys@0.13.0+1.56.2-patched:                  from grpc_wrap.cc:71:
warning: grpcio-sys@0.13.0+1.56.2-patched: /usr/include/absl/strings/string_view.h:53:26: error: 'string_view' in namespace 'std' does not name a type
warning: grpcio-sys@0.13.0+1.56.2-patched:    53 | using string_view = std::string_view;
warning: grpcio-sys@0.13.0+1.56.2-patched:       |                          ^~~~~~~~~~~
warning: grpcio-sys@0.13.0+1.56.2-patched: /usr/include/absl/strings/string_view.h:53:21: note: 'std::string_view' is only available from C++17 onwards
warning: grpcio-sys@0.13.0+1.56.2-patched:    53 | using string_view = std::string_view;
warning: grpcio-sys@0.13.0+1.56.2-patched:       |                     ^~~
```