### PR TITLE
659 gpr assert absl check cpp17

### DIFF
--- a/grpc-sys/build.rs
+++ b/grpc-sys/build.rs
@@ -443,7 +443,7 @@ fn bindgen_grpc(file_path: &Path) {
         .header("grpc_wrap.cc")
         .clang_arg("-xc++")
         .clang_arg("-I./grpc/include")
-        .clang_arg("-std=c++11")
+        .clang_arg("-std=c++14")
         .impl_debug(true)
         .size_t_is_usize(true)
         .disable_header_comment()
@@ -558,7 +558,7 @@ fn main() {
 
     cc.cpp(true);
     if !cfg!(target_env = "msvc") {
-        cc.flag("-std=c++11");
+        cc.flag("-std=c++14");
     }
     cc.file("grpc_wrap.cc");
     cc.warnings_into_errors(true);

--- a/grpc-sys/build.rs
+++ b/grpc-sys/build.rs
@@ -443,7 +443,7 @@ fn bindgen_grpc(file_path: &Path) {
         .header("grpc_wrap.cc")
         .clang_arg("-xc++")
         .clang_arg("-I./grpc/include")
-        .clang_arg("-std=c++14")
+        .clang_arg("-std=c++17")
         .impl_debug(true)
         .size_t_is_usize(true)
         .disable_header_comment()
@@ -558,7 +558,7 @@ fn main() {
 
     cc.cpp(true);
     if !cfg!(target_env = "msvc") {
-        cc.flag("-std=c++14");
+        cc.flag("-std=c++17");
     }
     cc.file("grpc_wrap.cc");
     cc.warnings_into_errors(true);

--- a/grpc-sys/grpc_wrap.cc
+++ b/grpc-sys/grpc_wrap.cc
@@ -66,6 +66,11 @@
 #define GPR_CALLTYPE
 #endif
 
+#ifndef GPR_ASSERT
+#include <assert.h>
+#define GPR_ASSERT assert
+#endif
+
 grpc_byte_buffer* string_to_byte_buffer(const char* buffer, size_t len) {
   grpc_slice slice = grpc_slice_from_copied_buffer(buffer, len);
   grpc_byte_buffer* bb = grpc_raw_byte_buffer_create(&slice, 1);

--- a/grpc-sys/grpc_wrap.cc
+++ b/grpc-sys/grpc_wrap.cc
@@ -67,8 +67,9 @@
 #endif
 
 #ifndef GPR_ASSERT
-#include <assert.h>
-#define GPR_ASSERT assert
+#include <string_view>
+#include <absl/log/absl_check.h>
+#define GPR_ASSERT ABSL_CHECK
 #endif
 
 grpc_byte_buffer* string_to_byte_buffer(const char* buffer, size_t len) {

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -105,7 +105,7 @@ fn clang_lint() {
         "-Igrpc-sys/grpc/include",
         "-x",
         "c++",
-        "-std=c++11",
+        "-std=c++14",
     ]));
     exec(cmd("clang-format").args(&["-i", "grpc-sys/grpc_wrap.cc"]));
 }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -105,7 +105,7 @@ fn clang_lint() {
         "-Igrpc-sys/grpc/include",
         "-x",
         "c++",
-        "-std=c++14",
+        "-std=c++17",
     ]));
     exec(cmd("clang-format").args(&["-i", "grpc-sys/grpc_wrap.cc"]));
 }


### PR DESCRIPTION
Upgrading C++ to C++17 makes `ABSL_CHECK` actually compile