### PR TITLE
fix benchmark build fail and test fail #664

### DIFF
--- a/benchmark/Cargo.toml
+++ b/benchmark/Cargo.toml
@@ -22,7 +22,7 @@ rand = "0.8"
 rand_distr = "0.4"
 rand_xorshift = "0.3"
 futures-timer = "3.0"
-clap = "4.5"
+clap = { version = "4.5", features = ["derive"] }
 log = "0.4"
 slog = "2.0"
 slog-async = "2.1"

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -17,6 +17,7 @@ $ git clone https://github.com/pingcap/grpc.git
 
 3. Build benchmark
 
+`grpc` and `grpc-rs` need to be in the same folder
 ```
 $ cd grpc-rs
 $ cargo xtask submodule

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -27,8 +27,10 @@ $ cargo build -p benchmark --release
 
 ```
 $ cd ../grpc
+$ git submodule update --init
 $ python3 tools/run_tests/run_performance_tests.py -l rust
 ```
+The recommended python version is 3.10
 
 Checkout `python3 tools/run_tests/run_performance_tests.py --help` to see custom options.
 

--- a/benchmark/src/main.rs
+++ b/benchmark/src/main.rs
@@ -33,7 +33,7 @@ struct WorkerCli {
 
 fn main() {
     let cli = WorkerCli::parse();
-    let port = cli.driver_port0.unwrap_or(cli.driver_port1.unwrap_or(32766));
+    let port = cli.driver_port0.unwrap_or(cli.driver_port1.unwrap_or(8080));
 
     let _log_guard = init_log(
         env::var(LOG_FILE)

--- a/benchmark/src/main.rs
+++ b/benchmark/src/main.rs
@@ -21,15 +21,19 @@ const LOG_FILE: &str = "GRPCIO_BENCHMARK_LOG_FILE";
 ///
 /// ref http://www.grpc.io/docs/guides/benchmarking.html.
 #[derive(Parser)]
+#[group(required = true, multiple = false)]
 struct WorkerCli {
     /// The port the worker should listen on. For example, 8080
-    #[arg(long)]
-    driver_port: Option<u16>,
+    #[arg(id = "driver_port", long)]
+    driver_port0: Option<u16>,
+    /// The port the worker should listen on. For example, 8080
+    #[arg(id = "driver-port", long)]
+    driver_port1: Option<u16>,
 }
 
 fn main() {
     let cli = WorkerCli::parse();
-    let port = cli.driver_port.unwrap_or(8080);
+    let port = cli.driver_port0.unwrap_or(cli.driver_port1.unwrap_or(32766));
 
     let _log_guard = init_log(
         env::var(LOG_FILE)


### PR DESCRIPTION
close issue: #664 
build benchmark fail.
we need to add `derive` feature when importing `clap` 
benchmark test fail.
we need to add the argument `--driver_port`