### PR TITLE
SinkBase::poll_ready may poll the batched future after completion when it returns Ready(Err(_))

### DIFF
--- a/src/call/mod.rs
+++ b/src/call/mod.rs
@@ -832,7 +832,9 @@ impl SinkBase {
         match &mut self.batch_f {
             None => return Poll::Ready(Ok(())),
             Some(f) => {
-                ready!(Pin::new(f).poll(cx)?);
+                ready!(Pin::new(f).poll(cx)).inspect_err(|_| {
+                    self.batch_f.take();
+                })?;
             }
         }
         self.batch_f.take();


### PR DESCRIPTION
This PR fixes a bug that could lead to `CqFuture` being polled after completion, and therefore causing a panic in the following scenario

Reproduction scenario:
1. A duplex streaming RPC is open and keep the sink across multiple requests
2. A write fails with a gRPC error (e.g. server drops the connection) — poll_ready returns Ready(Err(e)) but batch_f is not cleared
3. The next write attempt on the same sink calls poll_ready, which polls the stale CqFuture → panic

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling in batch processing so that internal batch work is cleared immediately on error, preventing stale state and improving reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->