### PR TITLE
client: handle unary response cardinality violations

### DIFF
--- a/src/call/client.rs
+++ b/src/call/client.rs
@@ -13,7 +13,7 @@ use futures_util::future::poll_fn;
 use futures_util::{ready, Sink, Stream};
 use parking_lot::Mutex;
 
-use super::{ShareCall, ShareCallHolder, SinkBase, WriteFlags};
+use super::{RpcStatus, RpcStatusCode, ShareCall, ShareCallHolder, SinkBase, WriteFlags};
 use crate::buf::GrpcSlice;
 use crate::call::{check_run, Call, MessageReader, Method};
 use crate::channel::Channel;
@@ -195,6 +195,15 @@ impl Call {
     }
 }
 
+fn take_single_response(message_reader: Option<MessageReader>) -> Result<MessageReader> {
+    message_reader.ok_or_else(|| {
+        Error::RpcFailure(RpcStatus::with_message(
+            RpcStatusCode::UNIMPLEMENTED,
+            "Response cardinality violation: expected exactly one response, got none".to_owned(),
+        ))
+    })
+}
+
 /// A receiver for unary request.
 ///
 /// The future is resolved once response is received.
@@ -241,7 +250,7 @@ impl<T> ClientUnaryReceiver<T> {
         let data = Pin::new(&mut self.resp_f).await?;
         self.initial_metadata = data.initial_metadata;
         self.trailing_metadata = data.trailing_metadata;
-        self.message = Some(self.resp_de(data.message_reader.unwrap())?);
+        self.message = Some(self.resp_de(take_single_response(data.message_reader)?)?);
         self.finished = true;
         Ok(())
     }
@@ -290,7 +299,11 @@ impl<T: Unpin> Future for ClientUnaryReceiver<T> {
         self.initial_metadata = data.initial_metadata;
         self.trailing_metadata = data.trailing_metadata;
         self.finished = true;
-        Poll::Ready(self.resp_de(data.message_reader.unwrap()))
+        let message_reader = match take_single_response(data.message_reader) {
+            Ok(message_reader) => message_reader,
+            Err(e) => return Poll::Ready(Err(e)),
+        };
+        Poll::Ready(self.resp_de(message_reader))
     }
 }
 
@@ -345,7 +358,7 @@ impl<T> ClientCStreamReceiver<T> {
         })
         .await?;
 
-        self.message = Some(self.resp_de(data.message_reader.unwrap())?);
+        self.message = Some(self.resp_de(take_single_response(data.message_reader)?)?);
         self.initial_metadata = data.initial_metadata;
         self.trailing_metadata = data.trailing_metadata;
         self.finished = true;
@@ -400,7 +413,11 @@ impl<T: Unpin> Future for ClientCStreamReceiver<T> {
         self.initial_metadata = data.initial_metadata;
         self.trailing_metadata = data.trailing_metadata;
         self.finished = true;
-        Poll::Ready((self.resp_de)(data.message_reader.unwrap()))
+        let message_reader = match take_single_response(data.message_reader) {
+            Ok(message_reader) => message_reader,
+            Err(e) => return Poll::Ready(Err(e)),
+        };
+        Poll::Ready((self.resp_de)(message_reader))
     }
 }
 

--- a/src/call/server.rs
+++ b/src/call/server.rs
@@ -251,7 +251,10 @@ impl UnaryRequestContext {
             return execute(self.request, cq, reader, handler, checker);
         }
 
-        let status = RpcStatus::with_message(RpcStatusCode::INTERNAL, "No payload".to_owned());
+        let status = RpcStatus::with_message(
+            RpcStatusCode::UNIMPLEMENTED,
+            "Request cardinality violation: expected exactly one request, got none".to_owned(),
+        );
         self.request.call(cq.clone()).abort(&status)
     }
 }

--- a/tests-and-examples/tests/cases/stream.rs
+++ b/tests-and-examples/tests/cases/stream.rs
@@ -1,5 +1,7 @@
 // Copyright 2020 TiKV Project Authors. Licensed under Apache-2.0.
 
+use std::io::Read;
+use std::mem::MaybeUninit;
 use std::sync::Arc;
 
 use futures_channel::mpsc;
@@ -10,12 +12,14 @@ use futures_util::{
     FutureExt as _, SinkExt as _, StreamExt as _, TryFutureExt as _, TryStreamExt as _,
 };
 use grpcio::{
-    ChannelBuilder, ClientStreamingSink, DuplexSink, EnvBuilder, RequestStream, RpcContext,
-    ServerBuilder, ServerCredentials, ServerStreamingSink, UnarySink, WriteFlags,
+    ChannelBuilder, Client, ClientStreamingSink, DuplexSink, EnvBuilder, GrpcSlice, Marshaller,
+    MessageReader, Method, MethodType, RequestStream, RpcContext, ServerBuilder, ServerCredentials,
+    ServerStreamingSink, UnarySink, WriteFlags,
 };
 use grpcio_proto::example::route_guide::*;
 
 const MESSAGE_NUM: i32 = 2000;
+const CARDINALITY_METHOD_NAME: &str = "/grpc.testing.Cardinality/EmptyResponse";
 
 #[derive(Clone)]
 struct RouteGuideService {}
@@ -72,6 +76,44 @@ macro_rules! assert_finish {
             Err(e) => panic!("unexpected error {:?}", e),
         }
     };
+}
+
+fn serialize_bytes(t: &Vec<u8>, buf: &mut GrpcSlice) -> grpcio::Result<()> {
+    unsafe {
+        let bytes = buf.realloc(t.len());
+        let bytes = &mut *(bytes as *mut [MaybeUninit<u8>] as *mut [u8]);
+        bytes.copy_from_slice(t);
+    }
+    Ok(())
+}
+
+fn deserialize_bytes(mut reader: MessageReader) -> grpcio::Result<Vec<u8>> {
+    let mut data = vec![];
+    reader.read_to_end(&mut data).unwrap();
+    Ok(data)
+}
+
+fn bytes_marshaller() -> Marshaller<Vec<u8>> {
+    Marshaller {
+        ser: serialize_bytes,
+        de: deserialize_bytes,
+    }
+}
+
+fn cardinality_method(ty: MethodType) -> Method<Vec<u8>, Vec<u8>> {
+    Method {
+        ty,
+        name: CARDINALITY_METHOD_NAME,
+        req_mar: bytes_marshaller(),
+        resp_mar: bytes_marshaller(),
+    }
+}
+
+fn assert_rpc_failure_code(err: grpcio::Error, code: grpcio::RpcStatusCode) {
+    match err {
+        grpcio::Error::RpcFailure(status) => assert_eq!(status.code(), code),
+        e => panic!("unexpected error: {e:?}"),
+    }
 }
 
 #[test]
@@ -156,4 +198,81 @@ fn test_client_send_all() {
         join!(recv_msg_task, close_sink_task);
     };
     block_on(exec_test_f);
+}
+
+#[test]
+fn test_unary_empty_response_returns_unimplemented() {
+    let env = Arc::new(EnvBuilder::new().build());
+    let service = grpcio::ServiceBuilder::new()
+        .add_server_streaming_handler(
+            &cardinality_method(MethodType::ServerStreaming),
+            |ctx: RpcContext<'_>, _: Vec<u8>, mut sink: ServerStreamingSink<Vec<u8>>| {
+                ctx.spawn(async move { sink.close().await.unwrap() });
+            },
+        )
+        .build();
+    let mut server = ServerBuilder::new(env.clone())
+        .register_service(service)
+        .build()
+        .unwrap();
+    let port = server
+        .add_listening_port("127.0.0.1:0", ServerCredentials::insecure())
+        .unwrap();
+    server.start();
+
+    let ch = ChannelBuilder::new(env).connect(&format!("127.0.0.1:{port}"));
+    let client = Client::new(ch);
+    let err = client
+        .unary_call(
+            &cardinality_method(MethodType::Unary),
+            &vec![1, 2, 3],
+            grpcio::CallOption::default(),
+        )
+        .unwrap_err();
+
+    assert_rpc_failure_code(err, grpcio::RpcStatusCode::UNIMPLEMENTED);
+}
+
+#[test]
+fn test_client_streaming_empty_response_returns_unimplemented() {
+    let env = Arc::new(EnvBuilder::new().build());
+    let service = grpcio::ServiceBuilder::new()
+        .add_duplex_streaming_handler(
+            &cardinality_method(MethodType::Duplex),
+            |ctx: RpcContext<'_>,
+             mut reqs: RequestStream<Vec<u8>>,
+             mut sink: DuplexSink<Vec<u8>>| {
+                ctx.spawn(async move {
+                    while reqs.try_next().await.unwrap().is_some() {}
+                    sink.close().await.unwrap();
+                });
+            },
+        )
+        .build();
+    let mut server = ServerBuilder::new(env.clone())
+        .register_service(service)
+        .build()
+        .unwrap();
+    let port = server
+        .add_listening_port("127.0.0.1:0", ServerCredentials::insecure())
+        .unwrap();
+    server.start();
+
+    let ch = ChannelBuilder::new(env).connect(&format!("127.0.0.1:{port}"));
+    let client = Client::new(ch);
+    let (mut sink, receiver) = client
+        .client_streaming(
+            &cardinality_method(MethodType::ClientStreaming),
+            grpcio::CallOption::default(),
+        )
+        .unwrap();
+
+    let err = block_on(async move {
+        sink.send((vec![1, 2, 3], WriteFlags::default())).await?;
+        sink.close().await?;
+        receiver.await
+    })
+    .unwrap_err();
+
+    assert_rpc_failure_code(err, grpcio::RpcStatusCode::UNIMPLEMENTED);
 }


### PR DESCRIPTION
### What changed
- Return UNIMPLEMENTED when unary-shaped client response paths receive OK without the required single message instead of panicking on a missing MessageReader.
- Align the server-side missing unary request payload case with the gRPC request cardinality violation status.
- Add regression coverage for unary and client-streaming empty-response violations.

### Tests
- cargo fmt --check
- git diff --check

Targeted integration tests were attempted but local execution is blocked because grpcio-sys requires cmake and this environment does not have cmake installed.

Fixes #670.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Unary and client-streaming calls now return a proper RPC error when the expected number of messages is missing, instead of failing unexpectedly.
  * Missing request payloads now report a clearer `UNIMPLEMENTED` status with a cardinality-related message.
* **Tests**
  * Added coverage for unary and client-streaming cardinality failures to verify the returned RPC status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->