### PR TITLE
server: mark shutdown before C-core shutdown

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -323,7 +323,7 @@ unsafe impl Send for RequestCallContext {}
 
 /// Request notification of a new call.
 pub fn request_call(ctx: RequestCallContext, cq: &CompletionQueue) {
-    if ctx.server.shutdown.load(Ordering::Relaxed) {
+    if ctx.server.shutdown.load(Ordering::SeqCst) {
         return;
     }
     let cq_ref = match cq.borrow() {
@@ -383,6 +383,10 @@ pub struct Server {
 impl Server {
     /// Shutdown the server asynchronously.
     pub fn shutdown(&mut self) -> ShutdownFuture {
+        // Stop request callbacks from registering new calls before C-core starts
+        // canceling pending requested calls.
+        self.core.shutdown.store(true, Ordering::SeqCst);
+
         let (cq_f, prom) = CallTag::action_pair();
         let prom_box = Box::new(prom);
         let tag = Box::into_raw(prom_box);
@@ -395,7 +399,6 @@ impl Server {
                 tag as *mut _,
             )
         }
-        self.core.shutdown.store(true, Ordering::SeqCst);
         ShutdownFuture { cq_f }
     }
 


### PR DESCRIPTION
### What problem does this PR solve?

Fixes #674.

`Server::shutdown()` currently marks `core.shutdown` after calling `grpc_server_shutdown_and_notify()`. During that window, C-core can cancel pending requested calls while grpc-rs request callbacks still observe `core.shutdown == false` and re-register `request_call()`. With many pending request slots, this can make the synchronous part of `Server::shutdown()` stall while C-core is cleaning pending work.

### What is changed?

- Mark `core.shutdown` before calling `grpc_server_shutdown_and_notify()`.
- Use the same `SeqCst` ordering when `request_call()` checks the shutdown flag.

This makes request callbacks stop registering new calls as soon as grpc-rs shutdown starts, before C-core begins canceling pending requested calls.

### Check List

Tests:

- `cargo fmt --all --check`
- `cargo test -p grpcio`
- `cargo test -p tests-and-examples`



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved server shutdown reliability by ensuring the system consistently stops registering new incoming request callbacks once shutdown starts.
  * Ensured pending requested calls are canceled consistently as part of the shutdown process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->